### PR TITLE
Add default prefix to cli

### DIFF
--- a/freezeyt/cli.py
+++ b/freezeyt/cli.py
@@ -8,7 +8,7 @@ from freezeyt.freezing import freeze
 @click.command()
 @click.argument('module_name')
 @click.argument('dest_path')
-@click.option('--prefix', help='URL of the application root')
+@click.option('--prefix', default='http://localhost:8000/', help='URL of the application root')
 def main(module_name, dest_path, prefix):
     """
     MODULE_NAME


### PR DESCRIPTION
when user doesn't write a prefix to cli program crashed. Prefix is None without default set of prefix.