### PR TITLE
add "prefix" to url_to_filename 

### DIFF
--- a/freezeyt/freezing.py
+++ b/freezeyt/freezing.py
@@ -19,7 +19,7 @@ def url_to_filename(base, url, hostname='localhost', port=8000, path='/'):
     if url_parse.scheme not in ('http', 'https'):
         raise ValueError("got URL that is not http")
 
-    if url_parse.hostname == hostname and port == port:
+    if url_parse.hostname == hostname and url_parse.port == port:
         url_path = url_parse.path
     else:
         raise ValueError(f"got external URL instead of {hostname}:{port}")

--- a/freezeyt/freezing.py
+++ b/freezeyt/freezing.py
@@ -19,7 +19,7 @@ def url_to_filename(base, url, hostname='localhost', port=8000, path='/'):
     if url_parse.scheme not in ('http', 'https'):
         raise ValueError("got URL that is not http")
 
-    if url_parse.netloc == '':
+    if not url_parse.netloc:
         raise ValueError("Need an absolute URL")
 
     if url_parse.hostname == hostname and port == port:

--- a/freezeyt/freezing.py
+++ b/freezeyt/freezing.py
@@ -69,7 +69,10 @@ def freeze(app, path, prefix='http://localhost:8000/'):
         visited_urls.add(url)
 
         try:
-            filename = url_to_filename(path, url)
+            filename = url_to_filename(path, url,
+                                        hostname=hostname,
+                                        port=port,
+                                        path=script_name)
         except ValueError:
             print('skipping', url)
             continue
@@ -77,6 +80,9 @@ def freeze(app, path, prefix='http://localhost:8000/'):
         print('link:', url)
 
         path_info = urlparse(url).path
+
+        if path_info.startswith(script_name):
+            path_info = "/" + path_info[len(script_name):]
 
         print('path_info:', path_info)
 

--- a/freezeyt/freezing.py
+++ b/freezeyt/freezing.py
@@ -22,7 +22,8 @@ def url_to_filename(base, url, hostname='localhost', port=8000, path='/'):
     if url_parse.hostname == hostname and url_parse.port == port:
         url_path = url_parse.path
     else:
-        raise ValueError(f"got external URL instead of {hostname}:{port}")
+        raise ValueError(f"Got external URL:{url}\
+                                    instead of {hostname}:{port}")
 
     if url_path.startswith(path):
         url_path = '/' + url_path[len(path):]
@@ -73,7 +74,8 @@ def freeze(app, path, prefix='http://localhost:8000/'):
                                         hostname=hostname,
                                         port=port,
                                         path=script_name)
-        except ValueError:
+        except ValueError as err:
+            print(err)
             print('skipping', url)
             continue
 

--- a/freezeyt/freezing.py
+++ b/freezeyt/freezing.py
@@ -14,13 +14,10 @@ def url_to_filename(base, url, hostname='localhost', port=8000, path='/'):
     """
     url_parse = urlparse(url)
 
-    if not url_parse.scheme:
+    if not url_parse.scheme or not url_parse.netloc:
         raise ValueError("Need an absolute URL")
     if url_parse.scheme not in ('http', 'https'):
         raise ValueError("got URL that is not http")
-
-    if not url_parse.netloc:
-        raise ValueError("Need an absolute URL")
 
     if url_parse.hostname == hostname and port == port:
         url_path = url_parse.path

--- a/test_demo.py
+++ b/test_demo.py
@@ -139,7 +139,7 @@ def test_flask_url_for(tmp_path):
     assert path3.exists()
 
 
-def test_flask_url_for_custom_prefix(tmp_path):
+def test_flask_url_for_custom_prefix_with_port(tmp_path):
     """Test an app unsing Flask url_for() with custom host & path
     """
 
@@ -149,6 +149,25 @@ def test_flask_url_for_custom_prefix(tmp_path):
         read_text = f.read()
 
     assert 'http://freezeyt.test:1234/foo/second_page.html' in read_text
+    assert '/foo/third_page.html' in read_text
+
+    path2 = tmp_path / "second_page.html"
+    assert path2.exists()
+
+    path3 = tmp_path / "third_page.html"
+    assert path3.exists()
+
+
+def test_flask_url_for_custom_prefix_without_port(tmp_path):
+    """Test an app unsing Flask url_for() with custom host & path
+    """
+
+    freeze(app_url_for, tmp_path, prefix='http://freezeyt.test/foo/')
+
+    with open(tmp_path / "index.html", encoding='utf-8') as f:
+        read_text = f.read()
+
+    assert 'http://freezeyt.test/foo/second_page.html' in read_text
     assert '/foo/third_page.html' in read_text
 
     path2 = tmp_path / "second_page.html"


### PR DESCRIPTION
Solve #40 

**Last commit** added new test for testing prefix without port.
I dont know how to handle this problem because urlparse return None if port doesnt exist.
And environ variable SERVER_PORT must be a string so than the environ make path as **example.com:none**