### PR TITLE
Check mimetype file with no suffix

### DIFF
--- a/freezeyt/freezing.py
+++ b/freezeyt/freezing.py
@@ -178,6 +178,8 @@ def get_links_from_node(node: xml.dom.minidom.Node, base_url) -> list:
 
 def check_mimetype(filename, headers):
     f_type, f_encode = guess_type(str(filename))
+    if not f_type:
+        f_type = 'application/octet-stream'
     headers = Headers(headers)
     cont_type, cont_encode = parse_options_header(headers.get('Content-Type'))
     if f_type.lower() != cont_type.lower():

--- a/tests/test_check_mimetype.py
+++ b/tests/test_check_mimetype.py
@@ -82,3 +82,23 @@ def test_same_jpg_fail():
                 ('Content-Length', '654'),
             ],
         )
+
+
+def test_missing_file_suffix():
+    check_mimetype(
+        '/tmp/index',
+        [
+            ('Content-Type', 'application/octet-stream'),
+            ('Content-Length', '164'),
+        ]
+    )
+
+def test_missing_file_suffix():
+    with pytest.raises(ValueError):
+        check_mimetype(
+            '/tmp/index',
+            [
+                ('Content-Type', 'image/png'),
+                ('Content-Length', '164'),
+            ]
+        )

--- a/tests/test_check_mimetype.py
+++ b/tests/test_check_mimetype.py
@@ -93,7 +93,7 @@ def test_missing_file_suffix():
         ]
     )
 
-def test_missing_file_suffix():
+def test_missing_file_suffix_fail():
     with pytest.raises(ValueError):
         check_mimetype(
             '/tmp/index',


### PR DESCRIPTION
fix #80 

There is some information to further discussion on stream:

I've found these topics on stackoverflow:
1. [How to get mimetypes from file ?](https://stackoverflow.com/questions/55319103/python-how-to-get-mimetypes-from-file-read-metadata)
1. [How to find the mime type of a file in python?](https://stackoverflow.com/questions/43580/how-to-find-the-mime-type-of-a-file-in-python)

And there are responds which inform that library mimetypes is not reliable. For better reliable result from some method they advice use library magic [python-magic pypi](https://pypi.org/project/python-magic/) but for these usage is necessary to install extra library `libmagic` which is different for each OS. So it could make more problems in our position than benefits.

What you think ?