### PR TITLE
Change "lesson" to "meeting" in articles

### DIFF
--- a/freezeyt_blog/articles/meeting07.md
+++ b/freezeyt_blog/articles/meeting07.md
@@ -1,4 +1,4 @@
-# Freezeyt lekce sedmá
+# Freezeyt sraz sedmý
 
 
 ## Review pull requestů
@@ -107,5 +107,5 @@ V reorganizaci testů budeme pokračovat příště.
 * `__name__` vrátí název modulu.
 * `__file__` vrátí název souboru s celou cestou a příponou.
 
-> Záznam z lekce [zde](https://youtu.be/DzpNvEarVAE).
+> Záznam ze srazu [zde](https://youtu.be/DzpNvEarVAE).
 Více informací o projektu [zde](https://tinyurl.com/freezeyt).

--- a/freezeyt_blog/articles/meeting11.md
+++ b/freezeyt_blog/articles/meeting11.md
@@ -57,5 +57,5 @@ Jakmile děláte force-push, měli byste vědět, co děláte.
 Příští aktualizace GitHub actions by mohla být, že každý nový článek se automaticky
 přidá na blog, který by byl hostovaný na [GH pages](https://pages.github.com/).
 
-> Záznam z lekce [zde](https://youtu.be/kFaDcOU7ZQo) a [zde](https://youtu.be/Q7ELr2clx5o).
+> Záznam ze srazu [zde](https://youtu.be/kFaDcOU7ZQo) a [zde](https://youtu.be/Q7ELr2clx5o).
 Více informací o projektu [zde](https://tinyurl.com/freezeyt).

--- a/freezeyt_blog/articles/meeting12.md
+++ b/freezeyt_blog/articles/meeting12.md
@@ -102,5 +102,5 @@ aby se místo dvou podtržítek nezobrazovaly tučně.
 
 Sraz jsme zakončili kontrolou otevřených issues a toho, co je potřeba udělat.
 
-> Záznam z lekce [zde](https://youtu.be/MonD2jaagK8).
+> Záznam ze srazu [zde](https://youtu.be/MonD2jaagK8).
 Více informací o projektu [zde](https://tinyurl.com/freezeyt).


### PR DESCRIPTION
Pull request https://github.com/encukou/freezeyt/pull/72 renamed the articles, bud didn't change the wording in the articles. Now, it should be meetups/meetings (_sraz_ in Czech) instead of lessons.