### PR TITLE
CLI tests

### DIFF
--- a/tests/fixtures/app_with_extra_page_deep/app.py
+++ b/tests/fixtures/app_with_extra_page_deep/app.py
@@ -1,0 +1,47 @@
+from flask import Flask
+
+app = Flask(__name__)
+freeze_config = {'extra_pages': ['/extra/', '/extra/extra_deep/']}
+
+
+@app.route('/')
+def index():
+    """Create the index page of the web app."""
+    return """
+    <html>
+        <head>
+            <title>Hello world</title>
+        </head>
+        <body>
+            Hello world!
+        </body>
+    </html>
+    """
+
+@app.route('/extra/')
+def extra():
+    return """
+    <html>
+        <head>
+            <title>Extra page</title>
+        </head>
+        <body>
+            This is unreachable via links.
+        </body>
+    </html>
+    """
+
+
+@app.route('/extra/extra_deep/')
+def extra_deep():
+    return """
+    <html>
+        <head>
+            <title>Extra DEEP page</title>
+        </head>
+        <body>
+            This is unreachable via links.
+            <strong>Extra Deep page</strong>
+        </body>
+    </html>
+    """

--- a/tests/fixtures/app_with_extra_page_deep/test_expected_output/extra/extra_deep/index.html
+++ b/tests/fixtures/app_with_extra_page_deep/test_expected_output/extra/extra_deep/index.html
@@ -1,0 +1,11 @@
+
+    <html>
+        <head>
+            <title>Extra DEEP page</title>
+        </head>
+        <body>
+            This is unreachable via links.
+            <strong>Extra Deep page</strong>
+        </body>
+    </html>
+    

--- a/tests/fixtures/app_with_extra_page_deep/test_expected_output/extra/index.html
+++ b/tests/fixtures/app_with_extra_page_deep/test_expected_output/extra/index.html
@@ -1,0 +1,10 @@
+
+    <html>
+        <head>
+            <title>Extra page</title>
+        </head>
+        <body>
+            This is unreachable via links.
+        </body>
+    </html>
+    

--- a/tests/fixtures/app_with_extra_page_deep/test_expected_output/index.html
+++ b/tests/fixtures/app_with_extra_page_deep/test_expected_output/index.html
@@ -1,0 +1,10 @@
+
+    <html>
+        <head>
+            <title>Hello world</title>
+        </head>
+        <body>
+            Hello world!
+        </body>
+    </html>
+    

--- a/tests/test_click_cli.py
+++ b/tests/test_click_cli.py
@@ -28,7 +28,7 @@ def test_cli_output(tmp_path, monkeypatch, app_name):
         print('MODULE:', module)
         cli_args = [str(module_path), str(tmp_path)]
 
-        for arg_name in 'prefix', 'extra_pages':
+        for arg_name in 'prefix', 'extra_pages', 'extra_files':
             arg_value = getattr(module, arg_name, None)
             if arg_value != None:
                 if arg_name == 'prefix':
@@ -36,6 +36,8 @@ def test_cli_output(tmp_path, monkeypatch, app_name):
                 elif arg_name == 'extra_pages':
                     for page in arg_value:
                         cli_args.extend(['--extra-page', page])
+                elif arg_name == 'extra_files':
+                    pytest.skip("extra_files not supported in CLI")
                 else:
                     cli_args.append(arg_value)
 

--- a/tests/test_click_cli.py
+++ b/tests/test_click_cli.py
@@ -1,7 +1,6 @@
 import importlib
 import pytest
 import sys
-import os
 
 from pathlib import Path
 
@@ -33,11 +32,10 @@ def test_cli_output(tmp_path, monkeypatch, app_name):
             arg_value = getattr(module, arg_name, None)
             if arg_value != None:
                 if arg_name == 'prefix':
-                    cli_args.append(f"--prefix {arg_value}")
+                    cli_args.extend(['--prefix', arg_value])
                 elif arg_name == 'extra_pages':
-                    add_option = lambda s: f"--extra-page {s}"
-                    extra_pages = list(map(add_option, arg_value))
-                    cli_args.extend(extra_pages)
+                    for page in arg_value:
+                        cli_args.extend(['--extra-page', page])
                 else:
                     cli_args.append(arg_value)
 

--- a/tests/test_click_cli.py
+++ b/tests/test_click_cli.py
@@ -12,7 +12,7 @@ from test_expected_output import APP_NAMES, FIXTURES_PATH, assert_dirs_same
 
 
 @pytest.mark.parametrize('app_name', APP_NAMES)
-def test_cli_with_fixtures_output(tmp_path, monkeypatch, app_name):
+def test_cli_with_fixtures_output(tmp_path, app_name):
     app_dir = Path('fixtures', app_name)
     expected = FIXTURES_PATH / app_name / 'test_expected_output'
     module_path = app_dir / 'app'
@@ -123,6 +123,46 @@ def test_cli_with_extra_page_option(tmp_path):
         assert result.exit_code == 0
 
         assert_dirs_same(tmp_path, expected)
+
+    finally:
+        sys.modules.pop('app', None)
+
+
+def test_cli_prefix_conflict(tmp_path):
+    module_path = Path('fixtures', 'demo_app_url_for_prefix', 'app')
+    module_path = '.'.join(module_path.parts)
+    expected = FIXTURES_PATH / 'demo_app_url_for_prefix' / 'test_expected_output'
+    config_file = tmp_path / 'config.yaml'
+    build_dir = tmp_path / 'build'
+    build_dir.mkdir()
+
+    runner = CliRunner()
+
+    try:
+        module = importlib.import_module(module_path)
+        freeze_config = getattr(module, 'freeze_config')
+        prefix = freeze_config['prefix']
+        cli_args = [str(module_path), str(build_dir), '--prefix', prefix]
+
+        data = {'prefix': 'http://pyladies.cz/lessons/'}
+        with open(config_file, mode='w') as file:
+            safe_dump(data, stream=file)
+
+        cli_args.extend(['--config', config_file])
+
+        result = runner.invoke(main, cli_args)
+
+        if not expected.exists():
+            if not 'TEST_CREATE_EXPECTED_OUTPUT' in os.environ:
+                raise AssertionError(
+                    f'Expected output directory ({expected}) does not exist. '
+                    + '\nRun $ python -m pytest test_expected_output.py\n'
+                    + 'And follow instructions'
+                    )
+
+        assert result.exit_code == 0
+
+        assert_dirs_same(build_dir, expected)
 
     finally:
         sys.modules.pop('app', None)

--- a/tests/test_click_cli.py
+++ b/tests/test_click_cli.py
@@ -1,7 +1,6 @@
 import importlib
 import os
 import sys
-from pathlib import Path
 from contextlib import contextmanager
 
 import pytest
@@ -53,7 +52,6 @@ def context_for_test(app_name, monkeypatch):
 
 @pytest.mark.parametrize('app_name', APP_NAMES)
 def test_cli_with_fixtures_output(tmp_path, app_name, monkeypatch):
-    app_dir = FIXTURES_PATH / app_name
     config_file = tmp_path / 'config.yaml'
     build_dir = tmp_path / 'build'
 
@@ -72,7 +70,6 @@ def test_cli_with_fixtures_output(tmp_path, app_name, monkeypatch):
 
 def test_cli_with_prefix_option(tmp_path, monkeypatch):
     app_name = 'demo_app_url_for_prefix'
-    app_dir = FIXTURES_PATH / app_name
     build_dir = tmp_path / 'build'
 
     with context_for_test(app_name, monkeypatch) as module:
@@ -85,7 +82,6 @@ def test_cli_with_prefix_option(tmp_path, monkeypatch):
 
 def test_cli_with_extra_page_option(tmp_path, monkeypatch):
     app_name = 'app_with_extra_page_deep'
-    app_dir = FIXTURES_PATH / app_name
     build_dir = tmp_path / 'build'
 
     with context_for_test(app_name, monkeypatch) as module:
@@ -105,7 +101,6 @@ def test_cli_with_extra_page_option(tmp_path, monkeypatch):
 
 def test_cli_prefix_conflict(tmp_path, monkeypatch):
     app_name = 'demo_app_url_for_prefix'
-    app_dir = FIXTURES_PATH / app_name
     config_file = tmp_path / 'config.yaml'
     build_dir = tmp_path / 'build'
 

--- a/tests/test_click_cli.py
+++ b/tests/test_click_cli.py
@@ -32,7 +32,7 @@ def test_cli_output(tmp_path, monkeypatch, app_name):
                     extra_pages = list(map(make_cli_arg, arg_value))
                     cli_args.extend(extra_pages)
                 else:
-                    cli_args.append = arg_value
+                    cli_args.append(arg_value)
 
 
         expected = app_path / 'test_expected_output'

--- a/tests/test_click_cli.py
+++ b/tests/test_click_cli.py
@@ -35,24 +35,23 @@ def test_cli_with_fixtures_output(tmp_path, app_name, monkeypatch):
 
             cli_args.extend(['--config', config_file])
 
+        result = runner.invoke(main, cli_args)
         if error_path.exists():
-            result = runner.invoke(main, cli_args)
             assert result.exit_code != 0
 
         else:
-            result = runner.invoke(main, cli_args)
-
             if not expected.exists():
-                if not 'TEST_CREATE_EXPECTED_OUTPUT' in os.environ:
+                if 'TEST_CREATE_EXPECTED_OUTPUT' in os.environ:
+                    pytest.skip('Expected output is created in other tests')
+                else:
                     raise AssertionError(
                         f'Expected output directory ({expected}) does not exist. '
-                        + '\nRun $ python -m pytest test_expected_output.py\n'
-                        + 'And follow instructions'
-                        )
+                        + 'Run with TEST_CREATE_EXPECTED_OUTPUT=1 to create it'
+                    )
+            else:
+                assert result.exit_code == 0
 
-            assert result.exit_code == 0
-
-            assert_dirs_same(build_dir, expected)
+                assert_dirs_same(build_dir, expected)
 
     finally:
         sys.modules.pop('app', None)

--- a/tests/test_click_cli.py
+++ b/tests/test_click_cli.py
@@ -11,15 +11,36 @@ from freezeyt.cli import main
 from test_expected_output import APP_NAMES, FIXTURES_PATH, assert_dirs_same
 
 
+def run_and_check(runner, cli_args, app_name, build_dir):
+    error_path = FIXTURES_PATH / app_name / 'error.txt'
+    expected = FIXTURES_PATH / app_name / 'test_expected_output'
+
+    build_dir.mkdir()
+
+    result = runner.invoke(main, cli_args)
+    if error_path.exists():
+        assert result.exit_code != 0
+
+    else:
+        if not expected.exists():
+            if 'TEST_CREATE_EXPECTED_OUTPUT' in os.environ:
+                pytest.skip('Expected output is created in other tests')
+            else:
+                raise AssertionError(
+                    f'Expected output directory ({expected}) does not exist. '
+                    + 'Run with TEST_CREATE_EXPECTED_OUTPUT=1 to create it'
+                )
+        else:
+            assert result.exit_code == 0
+
+            assert_dirs_same(build_dir, expected)
+
+
 @pytest.mark.parametrize('app_name', APP_NAMES)
 def test_cli_with_fixtures_output(tmp_path, app_name, monkeypatch):
     app_dir = FIXTURES_PATH / app_name
-    expected = FIXTURES_PATH / app_name / 'test_expected_output'
-    error_path = FIXTURES_PATH / app_name / 'error.txt'
     config_file = tmp_path / 'config.yaml'
     build_dir = tmp_path / 'build'
-
-    build_dir.mkdir()
 
     runner = CliRunner(env={'PYTHONPATH': str(app_dir)})
     monkeypatch.syspath_prepend(app_dir)
@@ -35,33 +56,16 @@ def test_cli_with_fixtures_output(tmp_path, app_name, monkeypatch):
 
             cli_args.extend(['--config', config_file])
 
-        result = runner.invoke(main, cli_args)
-        if error_path.exists():
-            assert result.exit_code != 0
-
-        else:
-            if not expected.exists():
-                if 'TEST_CREATE_EXPECTED_OUTPUT' in os.environ:
-                    pytest.skip('Expected output is created in other tests')
-                else:
-                    raise AssertionError(
-                        f'Expected output directory ({expected}) does not exist. '
-                        + 'Run with TEST_CREATE_EXPECTED_OUTPUT=1 to create it'
-                    )
-            else:
-                assert result.exit_code == 0
-
-                assert_dirs_same(build_dir, expected)
+        run_and_check(runner, cli_args, app_name, build_dir)
 
     finally:
         sys.modules.pop('app', None)
 
 
 def test_cli_with_prefix_option(tmp_path, monkeypatch):
-    app_dir = FIXTURES_PATH / 'demo_app_url_for_prefix'
-    expected = FIXTURES_PATH / 'demo_app_url_for_prefix' / 'test_expected_output'
+    app_name = 'demo_app_url_for_prefix'
+    app_dir = FIXTURES_PATH / app_name
     build_dir = tmp_path / 'build'
-    build_dir.mkdir()
 
     runner = CliRunner(env={'PYTHONPATH': str(app_dir)})
     monkeypatch.syspath_prepend(app_dir)
@@ -72,30 +76,16 @@ def test_cli_with_prefix_option(tmp_path, monkeypatch):
         prefix = freeze_config['prefix']
         cli_args = ['app', str(build_dir), '--prefix', prefix]
 
-        result = runner.invoke(main, cli_args)
-
-        if not expected.exists():
-            if 'TEST_CREATE_EXPECTED_OUTPUT' in os.environ:
-                pytest.skip('Expected output is created in other tests')
-            else:
-                raise AssertionError(
-                    f'Expected output directory ({expected}) does not exist. '
-                    + 'Run with TEST_CREATE_EXPECTED_OUTPUT=1 to create it'
-                )
-        else:
-            assert result.exit_code == 0
-
-            assert_dirs_same(build_dir, expected)
+        run_and_check(runner, cli_args, app_name, build_dir)
 
     finally:
         sys.modules.pop('app', None)
 
 
 def test_cli_with_extra_page_option(tmp_path, monkeypatch):
-    app_dir = FIXTURES_PATH / 'app_with_extra_page_deep'
-    expected = FIXTURES_PATH / 'app_with_extra_page_deep' / 'test_expected_output'
+    app_name = 'app_with_extra_page_deep'
+    app_dir = FIXTURES_PATH / app_name
     build_dir = tmp_path / 'build'
-    build_dir.mkdir()
 
     runner = CliRunner(env={'PYTHONPATH': str(app_dir)})
     monkeypatch.syspath_prepend(app_dir)
@@ -113,31 +103,17 @@ def test_cli_with_extra_page_option(tmp_path, monkeypatch):
 
         cli_args.extend(extra_pages)
 
-        result = runner.invoke(main, cli_args)
-
-        if not expected.exists():
-            if 'TEST_CREATE_EXPECTED_OUTPUT' in os.environ:
-                pytest.skip('Expected output is created in other tests')
-            else:
-                raise AssertionError(
-                    f'Expected output directory ({expected}) does not exist. '
-                    + 'Run with TEST_CREATE_EXPECTED_OUTPUT=1 to create it'
-                )
-        else:
-            assert result.exit_code == 0
-
-            assert_dirs_same(build_dir, expected)
+        run_and_check(runner, cli_args, app_name, build_dir)
 
     finally:
         sys.modules.pop('app', None)
 
 
 def test_cli_prefix_conflict(tmp_path, monkeypatch):
-    app_dir = FIXTURES_PATH / 'demo_app_url_for_prefix'
-    expected = FIXTURES_PATH / 'demo_app_url_for_prefix' / 'test_expected_output'
+    app_name = 'demo_app_url_for_prefix'
+    app_dir = FIXTURES_PATH / app_name
     config_file = tmp_path / 'config.yaml'
     build_dir = tmp_path / 'build'
-    build_dir.mkdir()
 
     runner = CliRunner(env={'PYTHONPATH': str(app_dir)})
     monkeypatch.syspath_prepend(app_dir)
@@ -154,20 +130,7 @@ def test_cli_prefix_conflict(tmp_path, monkeypatch):
 
         cli_args.extend(['--config', config_file])
 
-        result = runner.invoke(main, cli_args)
-
-        if not expected.exists():
-            if 'TEST_CREATE_EXPECTED_OUTPUT' in os.environ:
-                pytest.skip('Expected output is created in other tests')
-            else:
-                raise AssertionError(
-                    f'Expected output directory ({expected}) does not exist. '
-                    + 'Run with TEST_CREATE_EXPECTED_OUTPUT=1 to create it'
-                )
-        else:
-            assert result.exit_code == 0
-
-            assert_dirs_same(build_dir, expected)
+        run_and_check(runner, cli_args, app_name, build_dir)
 
     finally:
         sys.modules.pop('app', None)

--- a/tests/test_click_cli.py
+++ b/tests/test_click_cli.py
@@ -1,3 +1,7 @@
+import importlib
+import pytest
+import sys
+
 from click.testing import CliRunner
 from freezeyt import cli
 from test_expected_output import APP_NAMES, FIXTURES_PATH, assert_dirs_same
@@ -10,36 +14,45 @@ def test_cli_output(tmp_path, monkeypatch, app_name):
     app_path = FIXTURES_PATH / app_name
     error_path = app_path / 'error.txt'
 
-    # I dont know how to handle this convert
-    app = "path/to/app as path.to.module"
 
-    cli_args = [app, tmp_path]
+    # Add FIXTURES_PATH to sys.path, the list of directories that `import`
+    # looks in
+    monkeypatch.syspath_prepend(str(app_path))
+    try:
+        module = importlib.import_module('app')
+        # app = module.app
 
-    for arg_name in 'prefix', 'extra_pages':
-        arg_value = getattr(module, arg_name, None)
-        if arg_value != None:
-            if arg_name == 'extra_pages':
-                make_cli_arg = lambda s: f"--extra-page {s}"
-                extra_pages = list(map(make_cli_arg, arg_value))
-                cli_args.extend(extra_pages)
-            else:
-                cli_args.append = arg_value
+        cli_args = [module, tmp_path]
+
+        for arg_name in 'prefix', 'extra_pages':
+            arg_value = getattr(module, arg_name, None)
+            if arg_value != None:
+                if arg_name == 'extra_pages':
+                    make_cli_arg = lambda s: f"--extra-page {s}"
+                    extra_pages = list(map(make_cli_arg, arg_value))
+                    cli_args.extend(extra_pages)
+                else:
+                    cli_args.append = arg_value
 
 
-    expected = app_path / 'test_expected_output'
+        expected = app_path / 'test_expected_output'
 
-    if error_path.exists():
-        with pytest.raises(ValueError):
-            runner.invoke(cli, cli_args)
-    else:
-        runner.invoke(cli, cli_args)
+        if error_path.exists():
+            with pytest.raises(ValueError):
+                runner.invoke(cli, cli_args)
 
-        if not expected.exists():
-            raise AssertionError(
-                f'Expected output directory ({expected}) does not exist. '
-                + '\nRun $ python -m pytest test_expected_output.py\n'
-                + 'And follow instructions'
+        else:
+            result = runner.invoke(cli, cli_args)
+            print('Result:', result)
 
-                )
+            if not expected.exists():
+                raise AssertionError(
+                    f'Expected output directory ({expected}) does not exist. '
+                    + '\nRun $ python -m pytest test_expected_output.py\n'
+                    + 'And follow instructions'
 
-        assert_dirs_same(tmp_path, expected)
+                    )
+
+            assert_dirs_same(tmp_path, expected)
+    finally:
+        sys.modules.pop('app', None)

--- a/tests/test_click_cli.py
+++ b/tests/test_click_cli.py
@@ -2,6 +2,7 @@ import importlib
 import os
 import sys
 from pathlib import Path
+from contextlib import contextmanager
 
 import pytest
 from yaml import safe_dump
@@ -11,11 +12,14 @@ from freezeyt.cli import main
 from test_expected_output import APP_NAMES, FIXTURES_PATH, assert_dirs_same
 
 
-def run_and_check(runner, cli_args, app_name, build_dir):
+def run_and_check(cli_args, app_name, build_dir):
+    app_dir = FIXTURES_PATH / app_name
     error_path = FIXTURES_PATH / app_name / 'error.txt'
     expected = FIXTURES_PATH / app_name / 'test_expected_output'
 
     build_dir.mkdir()
+
+    runner = CliRunner(env={'PYTHONPATH': str(app_dir)})
 
     result = runner.invoke(main, cli_args)
     if error_path.exists():
@@ -36,17 +40,24 @@ def run_and_check(runner, cli_args, app_name, build_dir):
             assert_dirs_same(build_dir, expected)
 
 
+@contextmanager
+def context_for_test(app_name, monkeypatch):
+    app_dir = FIXTURES_PATH / app_name
+    monkeypatch.syspath_prepend(app_dir)
+    try:
+        module = importlib.import_module('app')
+        yield module
+    finally:
+        sys.modules.pop('app', None)
+
+
 @pytest.mark.parametrize('app_name', APP_NAMES)
 def test_cli_with_fixtures_output(tmp_path, app_name, monkeypatch):
     app_dir = FIXTURES_PATH / app_name
     config_file = tmp_path / 'config.yaml'
     build_dir = tmp_path / 'build'
 
-    runner = CliRunner(env={'PYTHONPATH': str(app_dir)})
-    monkeypatch.syspath_prepend(app_dir)
-
-    try:
-        module = importlib.import_module('app')
+    with context_for_test(app_name, monkeypatch) as module:
         cli_args = ['app', str(build_dir)]
         freeze_config = getattr(module, 'freeze_config', None)
 
@@ -56,10 +67,7 @@ def test_cli_with_fixtures_output(tmp_path, app_name, monkeypatch):
 
             cli_args.extend(['--config', config_file])
 
-        run_and_check(runner, cli_args, app_name, build_dir)
-
-    finally:
-        sys.modules.pop('app', None)
+        run_and_check(cli_args, app_name, build_dir)
 
 
 def test_cli_with_prefix_option(tmp_path, monkeypatch):
@@ -67,19 +75,12 @@ def test_cli_with_prefix_option(tmp_path, monkeypatch):
     app_dir = FIXTURES_PATH / app_name
     build_dir = tmp_path / 'build'
 
-    runner = CliRunner(env={'PYTHONPATH': str(app_dir)})
-    monkeypatch.syspath_prepend(app_dir)
-
-    try:
-        module = importlib.import_module('app')
+    with context_for_test(app_name, monkeypatch) as module:
         freeze_config = getattr(module, 'freeze_config')
         prefix = freeze_config['prefix']
         cli_args = ['app', str(build_dir), '--prefix', prefix]
 
-        run_and_check(runner, cli_args, app_name, build_dir)
-
-    finally:
-        sys.modules.pop('app', None)
+        run_and_check(cli_args, app_name, build_dir)
 
 
 def test_cli_with_extra_page_option(tmp_path, monkeypatch):
@@ -87,11 +88,7 @@ def test_cli_with_extra_page_option(tmp_path, monkeypatch):
     app_dir = FIXTURES_PATH / app_name
     build_dir = tmp_path / 'build'
 
-    runner = CliRunner(env={'PYTHONPATH': str(app_dir)})
-    monkeypatch.syspath_prepend(app_dir)
-
-    try:
-        module = importlib.import_module('app')
+    with context_for_test(app_name, monkeypatch) as module:
         cli_args = ['app', str(build_dir)]
 
         freeze_config = getattr(module, 'freeze_config')
@@ -103,10 +100,7 @@ def test_cli_with_extra_page_option(tmp_path, monkeypatch):
 
         cli_args.extend(extra_pages)
 
-        run_and_check(runner, cli_args, app_name, build_dir)
-
-    finally:
-        sys.modules.pop('app', None)
+        run_and_check(cli_args, app_name, build_dir)
 
 
 def test_cli_prefix_conflict(tmp_path, monkeypatch):
@@ -115,11 +109,7 @@ def test_cli_prefix_conflict(tmp_path, monkeypatch):
     config_file = tmp_path / 'config.yaml'
     build_dir = tmp_path / 'build'
 
-    runner = CliRunner(env={'PYTHONPATH': str(app_dir)})
-    monkeypatch.syspath_prepend(app_dir)
-
-    try:
-        module = importlib.import_module('app')
+    with context_for_test(app_name, monkeypatch) as module:
         freeze_config = getattr(module, 'freeze_config')
         prefix = freeze_config['prefix']
         cli_args = ['app', str(build_dir), '--prefix', prefix]
@@ -130,7 +120,4 @@ def test_cli_prefix_conflict(tmp_path, monkeypatch):
 
         cli_args.extend(['--config', config_file])
 
-        run_and_check(runner, cli_args, app_name, build_dir)
-
-    finally:
-        sys.modules.pop('app', None)
+        run_and_check(cli_args, app_name, build_dir)

--- a/tests/test_click_cli.py
+++ b/tests/test_click_cli.py
@@ -12,22 +12,21 @@ from test_expected_output import APP_NAMES, FIXTURES_PATH, assert_dirs_same
 
 
 @pytest.mark.parametrize('app_name', APP_NAMES)
-def test_cli_with_fixtures_output(tmp_path, app_name):
-    app_dir = Path('fixtures', app_name)
+def test_cli_with_fixtures_output(tmp_path, app_name, monkeypatch):
+    app_dir = FIXTURES_PATH / app_name
     expected = FIXTURES_PATH / app_name / 'test_expected_output'
-    module_path = app_dir / 'app'
     error_path = FIXTURES_PATH / app_name / 'error.txt'
     config_file = tmp_path / 'config.yaml'
     build_dir = tmp_path / 'build'
 
     build_dir.mkdir()
-    module_path = '.'.join(module_path.parts)
 
-    runner = CliRunner()
+    runner = CliRunner(env={'PYTHONPATH': str(app_dir)})
+    monkeypatch.syspath_prepend(app_dir)
 
     try:
-        module = importlib.import_module(module_path)
-        cli_args = [str(module_path), str(build_dir)]
+        module = importlib.import_module('app')
+        cli_args = ['app', str(build_dir)]
         freeze_config = getattr(module, 'freeze_config', None)
 
         if freeze_config != None:

--- a/tests/test_click_cli.py
+++ b/tests/test_click_cli.py
@@ -45,8 +45,8 @@ def test_cli_output(tmp_path, monkeypatch, app_name):
             # with pytest.raises(ValueError):
             # nevyvolava chybu
             result = runner.invoke(main, cli_args)
-            print('Result output:', result.output)
-            raise AssertionError
+            assert result.exit_code != 0
+
 
         else:
             result = runner.invoke(main, cli_args)

--- a/tests/test_click_cli.py
+++ b/tests/test_click_cli.py
@@ -3,7 +3,7 @@ import pytest
 import sys
 
 from click.testing import CliRunner
-from freezeyt import cli
+from freezeyt.cli import main
 from test_expected_output import APP_NAMES, FIXTURES_PATH, assert_dirs_same
 
 
@@ -39,10 +39,10 @@ def test_cli_output(tmp_path, monkeypatch, app_name):
 
         if error_path.exists():
             with pytest.raises(ValueError):
-                runner.invoke(cli, cli_args)
+                runner.invoke(main, cli_args)
 
         else:
-            result = runner.invoke(cli, cli_args)
+            result = runner.invoke(main, cli_args)
             print('Result:', result)
 
             if not expected.exists():

--- a/tests/test_click_cli.py
+++ b/tests/test_click_cli.py
@@ -1,0 +1,45 @@
+from click.testing import CliRunner
+from freezeyt import cli
+from test_expected_output import APP_NAMES, FIXTURES_PATH, assert_dirs_same
+
+
+
+@pytest.mark.parametrize('app_name', APP_NAMES)
+def test_cli_output(tmp_path, monkeypatch, app_name):
+    runner = CliRunner()
+    app_path = FIXTURES_PATH / app_name
+    error_path = app_path / 'error.txt'
+
+    # I dont know how to handle this convert
+    app = "path/to/app as path.to.module"
+
+    cli_args = [app, tmp_path]
+
+    for arg_name in 'prefix', 'extra_pages':
+        arg_value = getattr(module, arg_name, None)
+        if arg_value != None:
+            if arg_name == 'extra_pages':
+                make_cli_arg = lambda s: f"--extra-page {s}"
+                extra_pages = list(map(make_cli_arg, arg_value))
+                cli_args.extend(extra_pages)
+            else:
+                cli_args.append = arg_value
+
+
+    expected = app_path / 'test_expected_output'
+
+    if error_path.exists():
+        with pytest.raises(ValueError):
+            runner.invoke(cli, cli_args)
+    else:
+        runner.invoke(cli, cli_args)
+
+        if not expected.exists():
+            raise AssertionError(
+                f'Expected output directory ({expected}) does not exist. '
+                + '\nRun $ python -m pytest test_expected_output.py\n'
+                + 'And follow instructions'
+
+                )
+
+        assert_dirs_same(tmp_path, expected)


### PR DESCRIPTION
Draft #103 

I have problem to implement path to app as is required by importlab.import_module(). Normal OS format of path `path/to/app` returns Error - Module not found, to create importable path I can use just method replace('/', '.'). But this solution wont be usage of all OS types.