### PR TITLE
Mark test files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/tests/fixtures/*/test_expected_output -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-/tests/fixtures/*/test_expected_output -text
+/tests/fixtures/*/test_expected_output/** -text

--- a/tests/test_expected_output.py
+++ b/tests/test_expected_output.py
@@ -85,12 +85,8 @@ def assert_cmp_same(cmp):
     for filename in list(cmp.diff_files) + list(cmp.same_files):
         path1 = Path(cmp.left) / filename
         path2 = Path(cmp.right) / filename
-        try:
-            content1 = path1.read_text()
-            content2 = path2.read_text()
-        except UnicodeDecodeError:
-            content1 = path1.read_bytes()
-            content2 = path2.read_bytes()
+        content1 = path1.read_bytes()
+        content2 = path2.read_bytes()
         assert content1 == content2
 
     if cmp.diff_files:


### PR DESCRIPTION
This should make Git on Windows stop converting newlines.