### PR TITLE
is_external: Add checking and tests

### DIFF
--- a/freezeyt/util.py
+++ b/freezeyt/util.py
@@ -14,7 +14,7 @@ def is_external(parsed_url, prefix):
                 f'URL for is_external must have port set; got {url}'
             )
     prefix_path = prefix.path
-    if not prefix.path.endswith('/'):
+    if not prefix_path.endswith('/'):
         raise ValueError('prefix must end with /')
     if prefix_path == '/':
         prefix_path = ''

--- a/freezeyt/util.py
+++ b/freezeyt/util.py
@@ -6,13 +6,23 @@ from werkzeug.urls import url_parse
 def is_external(parsed_url, prefix):
     """Return true if the given URL is within a web app at `prefix`
 
-    Both arguments should be results of url_parse (or parse_absolute_url)
+    Both arguments should be results of parse_absolute_url
     """
+    for url in parsed_url, prefix:
+        if url.port is None:
+            raise ValueError(
+                f'URL for is_external must have port set; got {url}'
+            )
+    prefix_path = prefix.path
+    if not prefix.path.endswith('/'):
+        raise ValueError('prefix must end with /')
+    if prefix_path == '/':
+        prefix_path = ''
     return (
         parsed_url.scheme != prefix.scheme
         or parsed_url.ascii_host != prefix.ascii_host
         or parsed_url.port != prefix.port
-        or not parsed_url.path.startswith(prefix.path)
+        or not parsed_url.path.startswith(prefix_path)
     )
 
 

--- a/tests/test_is_external.py
+++ b/tests/test_is_external.py
@@ -1,0 +1,59 @@
+import pytest
+
+from freezeyt.util import is_external
+from werkzeug.urls import url_parse
+
+
+def test_is_external_positive():
+    assert not is_external(
+        url_parse('http://localhost:80/a/b/c'),
+        url_parse('http://localhost:80/a/'),
+    )
+
+
+def test_is_external_negative():
+    assert is_external(
+        url_parse('http://example.com:80/a/'),
+        url_parse('http://localhost:80/a/b/c/'),
+    )
+
+
+def test_is_external_negative_same_host():
+    assert is_external(
+        url_parse('http://localhost:80/a/'),
+        url_parse('http://localhost:80/a/b/c/'),
+    )
+
+
+def test_is_external_same():
+    assert not is_external(
+        url_parse('http://localhost:80/a/'),
+        url_parse('http://localhost:80/a/'),
+    )
+
+
+def test_is_external_index():
+    assert is_external(
+        url_parse('http://localhost:80/a'),
+        url_parse('http://localhost:80/a/'),
+    )
+
+
+def test_is_external_root_index():
+    assert not is_external(
+        url_parse('http://localhost:80'),
+        url_parse('http://localhost:80/'),
+    )
+
+
+def test_is_external_no_port():
+    with pytest.raises(ValueError):
+        is_external(
+            url_parse('http://localhost/a/'),
+            url_parse('http://localhost:80/a/'),
+        )
+    with pytest.raises(ValueError):
+        is_external(
+            url_parse('http://localhost:80/a/'),
+            url_parse('http://localhost/a/'),
+        )


### PR DESCRIPTION
The arguments to `is_external` must have port set, otherwise the checking fails (e.g. `http://localhost/a/b/c` is considered external to `http://localhost:80/a/b/c`)
One way to solve this would be to add the port in `is_external`, but I think it's nicer to make sure the port is always set. That way, we'll be more likely to use URLS with a port throughout freezeyt.