### PR TITLE
Manage pages to freeze as Task objects

### DIFF
--- a/freezeyt/freezer.py
+++ b/freezeyt/freezer.py
@@ -50,7 +50,7 @@ def check_mimetype(url_path, headers):
 @dataclasses.dataclass
 class Task:
     path: Path
-    urls: set[URL]
+    urls: "set[URL]"
     redirect: "Task" = None
 
 

--- a/freezeyt/freezer.py
+++ b/freezeyt/freezer.py
@@ -1,17 +1,20 @@
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from mimetypes import guess_type
 import io
 import itertools
 import functools
 import base64
+import dataclasses
+from typing import Optional
 
 from urllib.parse import urljoin
 from werkzeug.datastructures import Headers
 from werkzeug.http import parse_options_header
-from werkzeug.urls import url_parse
+from werkzeug.urls import URL
 
 from freezeyt.encoding import encode_wsgi_path, decode_input_path
+from freezeyt.encoding import encode_file_path
 from freezeyt.filesaver import FileSaver
 from freezeyt.dictsaver import DictSaver
 from freezeyt.util import parse_absolute_url, is_external
@@ -44,6 +47,13 @@ def check_mimetype(url_path, headers):
         )
 
 
+@dataclasses.dataclass
+class Task:
+    path: Path
+    urls: set[URL]
+    redirect: "Task" = None
+
+
 class Freezer:
     def __init__(self, app, config):
         self.app = app
@@ -71,10 +81,58 @@ class Freezer:
         else:
             self.saver = FileSaver(Path(output['dir']), self.prefix)
 
+        self.done_tasks = {}
+
+        self.pending_tasks = {}
+        self.add_task(prefix_parsed)
+        self._add_extra_pages(prefix, self.extra_pages)
+
+
     def get_result(self):
         get_result = getattr(self.saver, 'get_result', None)
         if get_result is not None:
             return self.saver.get_result()
+
+    def add_task(self, url: URL) -> Optional[Task]:
+        """Add a task to freeze the given URL
+
+        If no task is added (e.g. for external URLs), return None.
+        """
+        if is_external(url, self.prefix):
+            return None
+
+        path = self.url_to_path(url)
+
+        if path in self.pending_tasks:
+            task = self.pending_tasks[path]
+            task.urls.add(url)
+            return task
+        elif path in self.done_tasks:
+            task = self.done_tasks[path]
+            task.urls.add(url)
+            return task
+        else:
+            task = Task(path, {url})
+            self.pending_tasks[path] = task
+            return task
+
+    def url_to_path(self, parsed_url):
+        if is_external(parsed_url, self.prefix):
+            raise ValueError(f'external url {parsed_url}')
+
+        url_path = parsed_url.path
+
+        if url_path.startswith(self.prefix.path):
+            url_path = url_path[len(self.prefix.path):]
+
+        if url_path.endswith('/') or not url_path:
+            url_path = url_path + 'index.html'
+
+        result = PurePosixPath(encode_file_path(url_path))
+
+        assert not result.is_absolute(), result
+
+        return result
 
     def freeze_extra_files(self):
         if self.extra_files is not None:
@@ -110,7 +168,7 @@ class Freezer:
         Arguments:
             wsgi_write: function that the application can call to output data
             status: HTTP status line, like '200 OK'
-            headers: Dict of HTTP headers
+            headers: HTTP headers (list of tuples)
             exc_info: Information about a server error, if any.
                 Will be raised if given.
         """
@@ -118,20 +176,21 @@ class Freezer:
             exc_type, value, traceback = exc_info
             if value is not None:
                 raise value
+        self.response_headers = Headers(headers)
         if status.startswith("3"):
+            print(f"Redirect {self.url.to_url()} to {self.response_headers['Location']}")
             redirect_policy = self.config.get('redirect_policy', 'error')
             if redirect_policy == 'save':
                 status = "200"
         if not status.startswith("200"):
-            raise ValueError("Found broken link.")
+            raise ValueError(f"Found broken link: {self.url.to_url()}, status {status}")
         else:
             print('status', status)
             print('headers', headers)
-            check_mimetype(url_parse(self.url).path, headers)
-            self.response_headers = Headers(headers)
+            check_mimetype(self.url.path, headers)
         return wsgi_write
 
-    def _add_extra_pages(self, urls, prefix, extras):
+    def _add_extra_pages(self, prefix, extras):
         """Add URLs of extra pages from config.
 
         Handles both literal URLs and generators.
@@ -141,36 +200,31 @@ class Freezer:
                 generator = extra['generator']
                 if isinstance(generator, str):
                     generator = import_variable_from_module(generator)
-                self._add_extra_pages(urls, prefix, generator(self.app))
+                self._add_extra_pages(prefix, generator(self.app))
             elif isinstance(extra, str):
-                urls.append(urljoin(prefix, decode_input_path(extra)))
+                url = urljoin(prefix, decode_input_path(extra))
+                self.add_task(parse_absolute_url(url))
             else:
                 generator = extra
-                self._add_extra_pages(urls, prefix, generator(self.app))
+                self._add_extra_pages(prefix, generator(self.app))
 
     def handle_urls(self):
-        prefix = self.prefix.to_url()
-        new_urls = [prefix]
-        self._add_extra_pages(new_urls, prefix, self.extra_pages)
+        while self.pending_tasks:
+            file_path, task = self.pending_tasks.popitem()
 
-        visited_urls = set()
+            # Get an URL from the task's set of URLs
+            url_parsed = next(iter(task.urls))
+            self.url = url_parsed
 
-        while new_urls:
-            url = new_urls.pop()
-            self.url = url
+            # url_string should not be needed (except for debug messages)
+            url_string = url_parsed.to_url()
 
-            if url in visited_urls:
+            if task.path in self.done_tasks:
                 continue
 
-            visited_urls.add(url)
+            self.done_tasks[task.path] = task
 
-            url_parsed = parse_absolute_url(url)
-
-            if is_external(url_parsed, self.prefix):
-                print('skipping external', url)
-                continue
-
-            print('link:', url)
+            print('task:', task)
 
             path_info = url_parsed.path
 
@@ -235,8 +289,11 @@ class Freezer:
             with self.saver.open(url_parsed) as f:
                 cont_type, cont_encode = parse_options_header(self.response_headers.get('Content-Type'))
                 if cont_type == "text/html":
-                    new_urls.extend(get_all_links(f, url, self.response_headers))
+                    links = get_all_links(f, url_string, self.response_headers)
+                    for new_url in links:
+                        self.add_task(parse_absolute_url(new_url))
                 elif cont_type == "text/css":
-                    new_urls.extend(get_links_from_css(f, url))
+                    for new_url in get_links_from_css(f, url_string):
+                        self.add_task(parse_absolute_url(new_url))
                 else:
                     continue

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ html5lib
 click
 css-parser
 pyyaml
+dataclasses;python_version<"3.7"


### PR DESCRIPTION
In preparation for handling redirects, this makes freezeyt manage pages to freeze (and pages it already froze) as Task objects.