### PR TITLE
Remove unnecessary print in blog app

### DIFF
--- a/freezeyt_blog/app.py
+++ b/freezeyt_blog/app.py
@@ -94,7 +94,6 @@ def article_image(filename):
     (mimetype, encoding) = mimetypes.guess_type(img_path)
     if mimetype:
         img_bytes = img_path.read_bytes()
-        print(mimetype)
 
         return Response(img_bytes, mimetype=mimetype)
 


### PR DESCRIPTION
During the blog freezing, the console is filled with `image/png` debug prints.
If this isn't a debug print and it has a special purpose, feel free to close this PR. 😄 