### PR TITLE
Change middleware in Django project

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -2,5 +2,4 @@ pytest >= 6.2.0
 flask
 pyflakes
 Django
-wsgi-static-middleware
 bottle

--- a/tests/fixtures/project_django/app.py
+++ b/tests/fixtures/project_django/app.py
@@ -1,15 +1,12 @@
-from pathlib import Path
-from wsgi_static_middleware import StaticMiddleware
+import os
+
+from werkzeug.middleware.shared_data import SharedDataMiddleware
 
 from demo_project.wsgi import application as django_wsgi_app
 
-BASE_PATH = Path(__file__).parent
-STATIC_DIRS = [BASE_PATH / 'static']
-
-
-app = StaticMiddleware(
-    django_wsgi_app, static_root='/static', static_dirs=STATIC_DIRS
-)
+app = SharedDataMiddleware(django_wsgi_app, {
+    '/static': os.path.join(os.path.dirname(__file__), 'static')
+})
 
 freeze_config = {'extra_pages': ['/extra/']}
 


### PR DESCRIPTION
Switch from `wsgi-static-middleware`
to `werkzeug.middleware.shared_data.SharedDataMiddleware`
in Django test project.

Fixes https://github.com/encukou/freezeyt/issues/218
Fixes https://github.com/encukou/freezeyt/issues/108
Should help with https://github.com/encukou/freezeyt/pull/217