### PR TITLE
Switch 'output: dict' to 'output: {type: dict}' in one more test

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -70,7 +70,7 @@ def test_cli_to_dict_with_config_and_path(tmp_path, monkeypatch):
     config_path = tmp_path / 'freezeyt.conf'
     app_name = 'app_with_extra_files'
 
-    config_path.write_text('output: dict')
+    config_path.write_text('output: {type: dict}')
 
     result = run_freezeyt_cli(
         ['app', '-c', config_path, str(builddir)], app_name, check=False


### PR DESCRIPTION
`output: dict` means "save to a directory called `dict`".