### PR TITLE
Add links with interesting python concept

### DIFF
--- a/freezeyt_blog/app.py
+++ b/freezeyt_blog/app.py
@@ -54,21 +54,20 @@ def render_img(self, tokens, idx, options, env):
 @app.route('/')
 def index():
     """Start page with list of articles."""
-    post_slugs = [a.stem for a in sorted(ARTICLES_PATH.glob('*.md'))]
-    post_names = []
-    for article in sorted(ARTICLES_PATH.glob('*.md')):
+    articles = sorted(ARTICLES_PATH.glob('*.md'))
+    post_info = []
+
+    for article in articles:
         with open(article, encoding='utf-8') as a:
             title = a.readline()
-            if title.startswith("# "):
-                post_names.append(title[2:])
-            else:
+            if not title.startswith("# "):
                 raise ValueError("Post must begin with a title.")
-    post_info = zip(post_slugs, post_names)
 
-    return render_template(
-        'index.html',
-        post_info=post_info
-    )
+        slug = article.stem
+        title = title.lstrip("# ").strip()
+        post_info.append((slug, title))
+
+    return render_template('index.html', post_info=post_info)
 
 
 @app.route('/<slug>/')
@@ -86,10 +85,7 @@ def post(slug):
     renderer.add_render_rule("image", render_img)
     html_content = renderer.render(md_content)
 
-    return render_template(
-        'post.html',
-        content=html_content,
-    )
+    return render_template('post.html', content=html_content)
 
 
 @app.route('/article_image/<filename>')

--- a/freezeyt_blog/articles/concepts_list.md
+++ b/freezeyt_blog/articles/concepts_list.md
@@ -1,0 +1,10 @@
+# Python koncepty
+
+
+### contextmanager
+* [docs](https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager)
+* [freezeeyt-yt-video-73 (00:52:30)](https://www.youtube.com/watch?v=khUfxwQKX6s&list=PLFt-PM7J_H3EU5Oez3ZSVjY5pZJttP2lT&index=73)
+
+### async
+* přidej
+

--- a/freezeyt_blog/templates/index.html
+++ b/freezeyt_blog/templates/index.html
@@ -3,6 +3,15 @@
 <h1>Vítejte na blogu o projektu freezeyt!</h1>
 
 <div>
+    Odkazy na konkrétně použité koncepty:
+</div>
+<ul class="list-unstyled">
+    <li>
+        <a href={{ url_for('post', slug="concepts_list") }}>Python koncepty</a>
+    </li>
+</ul>
+
+<div>
 Všechny články k projektu:
 </div>
 <ul class="list-unstyled">

--- a/freezeyt_blog/templates/index.html
+++ b/freezeyt_blog/templates/index.html
@@ -15,14 +15,14 @@
 Všechny články k projektu:
 </div>
 <ul class="list-unstyled">
-{% for post_slug, post_name in post_info %}
-    {% if post_slug == "meeting01" or post_slug == "meeting33" %}
+{% for slug, title in post_info %}
+    {% if slug == "meeting01" or slug == "meeting33" %}
         <li>
-            <a href={{ url_for('post', slug=post_slug) }}><strong>{{ post_name }}</strong></a>
+            <a href={{ url_for('post', slug=slug) }}><strong>{{ title }}</strong></a>
         </li>
     {% else %}
         <li>
-            <a href={{ url_for('post', slug=post_slug) }}>{{ post_name }}</a>
+            <a href={{ url_for('post', slug=slug) }}>{{ title }}</a>
         </li>
     {% endif %}
 {% endfor %}


### PR DESCRIPTION
I miss some page in blog where can I easily find some interesting topics which I'd like to play again after some time.
When I won't remember exact the number of stream video where the topic was showed, then it is really hard to find it.

Same problem is with articles because I have to go through each article and check if the topic is mentioned there. We have a lot articles now and the finding process is pain.

I made it up, that each of us can add any interesting topic for him which can be found later in list in special article called `concepts_list.md`. Downside of this approach is that you mustn't to forget to add.

Extra thing I've done I little refactor the code. I hope that the code is more readable now.