### PR TITLE
Make sure MultiError works with exception groups in Python 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         tox_env: ${{ matrix.tox_env }}
     strategy:
       matrix:
-        tox_env: [py36, py37, py38, py39, py310, pyflakes, mypy]
+        tox_env: [py36, py37, py38, py39, py310, py311, pyflakes, mypy]
 
     # Use GitHub's Linux Docker host
     runs-on: ubuntu-latest

--- a/freezeyt/cli.py
+++ b/freezeyt/cli.py
@@ -96,22 +96,5 @@ def main(
 
     try:
         freeze(app, config)
-    except MultiError as multierr:
-        if sys.stderr.isatty():
-            cols, lines = shutil.get_terminal_size()
-            message = f' {multierr} '
-            click.echo(file=sys.stderr)
-            click.secho(message.center(cols, '='), file=sys.stderr, fg='red')
-        for task in multierr.tasks:
-            message = str(task.exception)
-            if message:
-                # Separate the error type and value by a semicolon
-                # (only if there is a value)
-                message = ': ' + message
-            err_type = click.style(type(task.exception).__name__, fg='red')
-            path = click.style(task.path, fg='cyan')
-            click.echo(f'{err_type}{message}', file=sys.stderr)
-            click.echo(f'  in {path}', file=sys.stderr)
-            for reason in task.reasons:
-                click.echo(f'    {reason}', file=sys.stderr)
-        exit(1)
+    except* TypeError:
+        pass

--- a/freezeyt/cli.py
+++ b/freezeyt/cli.py
@@ -96,5 +96,22 @@ def main(
 
     try:
         freeze(app, config)
-    except* TypeError:
-        pass
+    except MultiError as multierr:
+        if sys.stderr.isatty():
+            cols, lines = shutil.get_terminal_size()
+            message = f' {multierr} '
+            click.echo(file=sys.stderr)
+            click.secho(message.center(cols, '='), file=sys.stderr, fg='red')
+        for task in multierr.tasks:
+            message = str(task.exception)
+            if message:
+                # Separate the error type and value by a semicolon
+                # (only if there is a value)
+                message = ': ' + message
+            err_type = click.style(type(task.exception).__name__, fg='red')
+            path = click.style(task.path, fg='cyan')
+            click.echo(f'{err_type}{message}', file=sys.stderr)
+            click.echo(f'  in {path}', file=sys.stderr)
+            for reason in task.reasons:
+                click.echo(f'    {reason}', file=sys.stderr)
+        exit(1)

--- a/freezeyt/compat.py
+++ b/freezeyt/compat.py
@@ -44,3 +44,14 @@ def get_running_loop():
         return asyncio.get_event_loop()
     else:
         return get_loop()
+
+
+# In Python 3.11, freezeyt's MultiError derives from ExceptionGroup
+# and can be used with the `except*` statement.
+# In older versions, it derives from Exception instead.
+if sys.version_info >= (3, 11):
+    _MultiErrorBase = ExceptionGroup
+    HAVE_EXCEPTION_GROUP = True
+else:
+    _MultiErrorBase = Exception
+    HAVE_EXCEPTION_GROUP = False

--- a/freezeyt/util.py
+++ b/freezeyt/util.py
@@ -1,5 +1,6 @@
 import importlib
 import concurrent.futures
+import sys
 
 from werkzeug.urls import url_parse
 
@@ -7,10 +8,10 @@ from werkzeug.urls import url_parse
 # In Python 3.11, freezeyt's MultiError derives from ExceptionGroup
 # and can be used with the `except*` statement.
 # In older versions, it derives from Exception instead.
-try:
+if sys.version_info >= (3, 11):
     _MultiErrorBase = ExceptionGroup
     HAVE_EXCEPTION_GROUP = True
-except NameError:
+else:
     _MultiErrorBase = Exception
     HAVE_EXCEPTION_GROUP = False
 

--- a/freezeyt/util.py
+++ b/freezeyt/util.py
@@ -1,19 +1,9 @@
 import importlib
 import concurrent.futures
-import sys
 
 from werkzeug.urls import url_parse
 
-
-# In Python 3.11, freezeyt's MultiError derives from ExceptionGroup
-# and can be used with the `except*` statement.
-# In older versions, it derives from Exception instead.
-if sys.version_info >= (3, 11):
-    _MultiErrorBase = ExceptionGroup
-    HAVE_EXCEPTION_GROUP = True
-else:
-    _MultiErrorBase = Exception
-    HAVE_EXCEPTION_GROUP = False
+from freezeyt.compat import _MultiErrorBase, HAVE_EXCEPTION_GROUP
 
 
 process_pool_executor = concurrent.futures.ProcessPoolExecutor()

--- a/freezeyt/util.py
+++ b/freezeyt/util.py
@@ -4,6 +4,13 @@ from functools import cached_property
 
 from werkzeug.urls import url_parse
 
+try:
+    ExceptionGroup
+    HAVE_EXCEPTION_GROUP = True
+except NameError:
+    ExceptionGroup = Exception
+    HAVE_EXCEPTION_GROUP = False
+
 
 process_pool_executor = concurrent.futures.ProcessPoolExecutor()
 
@@ -54,7 +61,11 @@ class MultiError(ExceptionGroup):
             exc._freezeyt_exception_task = task
             exceptions.append(exc)
 
-        self = super().__new__(cls, f"{len(tasks)} errors", exceptions)
+        if HAVE_EXCEPTION_GROUP:
+            self = super().__new__(cls, f"{len(tasks)} errors", exceptions)
+        else:
+            self = super().__new__(cls, f"{len(tasks)} errors")
+            self.exceptions = exceptions
 
         self._tasks = tasks
         self.tasks = [TaskInfo(t) for t in tasks]

--- a/freezeyt/util.py
+++ b/freezeyt/util.py
@@ -1,6 +1,5 @@
 import importlib
 import concurrent.futures
-from functools import cached_property
 
 from werkzeug.urls import url_parse
 

--- a/freezeyt/util.py
+++ b/freezeyt/util.py
@@ -3,11 +3,15 @@ import concurrent.futures
 
 from werkzeug.urls import url_parse
 
+
+# In Python 3.11, freezeyt's MultiError derives from ExceptionGroup
+# and can be used with the `except*` statement.
+# In older versions, it derives from Exception instead.
 try:
-    ExceptionGroup
+    _MultiErrorBase = ExceptionGroup
     HAVE_EXCEPTION_GROUP = True
 except NameError:
-    ExceptionGroup = Exception
+    _MultiErrorBase = Exception
     HAVE_EXCEPTION_GROUP = False
 
 
@@ -47,7 +51,7 @@ class WrongMimetypeError(ValueError):
             + f" guessed from '{url_path}'"
         )
 
-class MultiError(ExceptionGroup):
+class MultiError(_MultiErrorBase):
     """Contains multiple errors"""
     def __new__(cls, tasks):
         # Import TaskInfo here to avoid a circular import

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+
+collect_ignore = []
+
+if sys.version_info < (3, 11):
+    # ExceptionGroup is only available in Python 3.11+
+    collect_ignore.append("test_multierror.py")

--- a/tests/fixtures/app_various_errors/app.py
+++ b/tests/fixtures/app_various_errors/app.py
@@ -1,0 +1,34 @@
+from flask import Flask, url_for
+
+app = Flask(__name__)
+app.config['PROPAGATE_EXCEPTIONS'] = True
+
+
+@app.route('/')
+def index():
+    return f"""
+    <html>
+        <head>
+            <title>Hello world</title>
+        </head>
+        <body>
+            Hello world!
+            <a href="nowhere">Link to nowhere</a>
+            <a href="{url_for('value_error')}">Link</a>
+            <a href="{url_for('type_error')}">Link</a>
+            <a href="{url_for('type_error2')}">Link</a>
+        </body>
+    </html>
+    """
+
+@app.route('/value_error')
+def value_error():
+    raise ValueError()
+
+@app.route('/type_error')
+def type_error():
+    raise TypeError()
+
+@app.route('/type_error2')
+def type_error2():
+    raise TypeError()

--- a/tests/fixtures/app_various_errors/error.txt
+++ b/tests/fixtures/app_various_errors/error.txt
@@ -1,0 +1,5 @@
+MultiError:
+    TypeError
+    TypeError
+    UnexpectedStatus
+    ValueError

--- a/tests/fixtures/bottle_app/app.py
+++ b/tests/fixtures/bottle_app/app.py
@@ -1,5 +1,16 @@
-from bottle import Bottle, static_file
+import sys
 from pathlib import Path
+
+try:
+    from bottle import Bottle, static_file
+except ImportError:
+    if sys.version_info[:2] == (3, 11):
+        # Bottle doesn't work in Python 3.11:
+        # https://github.com/bottlepy/bottle/issues/1070
+        import pytest
+        pytest.skip("Bottle doesn't work in Python 3.11")
+    else:
+        raise
 
 STATIC_PATH = Path(__file__).parent / 'static'
 

--- a/tests/test_multierror.py
+++ b/tests/test_multierror.py
@@ -1,4 +1,7 @@
-# These tests only run on Python 3.11+
+# This tests that MultiError is usable as an ExceptionGroup
+# with the `except*` statement in Python 3.11+.
+#
+# The tests are skipped on lower versions.
 
 from testutil import context_for_test
 

--- a/tests/test_multierror.py
+++ b/tests/test_multierror.py
@@ -1,6 +1,6 @@
 # These tests only run on Python 3.11+
 
-from testutil import FIXTURES_PATH, context_for_test, assert_dirs_same
+from testutil import context_for_test
 
 from freezeyt import freeze, UnexpectedStatus
 

--- a/tests/test_multierror.py
+++ b/tests/test_multierror.py
@@ -1,3 +1,5 @@
+# These tests only run on Python 3.11+
+
 from testutil import FIXTURES_PATH, context_for_test, assert_dirs_same
 
 from freezeyt import freeze, UnexpectedStatus

--- a/tests/test_multierror.py
+++ b/tests/test_multierror.py
@@ -1,0 +1,36 @@
+from testutil import FIXTURES_PATH, context_for_test, assert_dirs_same
+
+from freezeyt import freeze, UnexpectedStatus
+
+
+def test_except_star():
+    with context_for_test('app_various_errors') as module:
+        app = module.app
+        config = {
+            'output': {'type': 'dict'},
+        }
+
+        try:
+            freeze(app, config)
+        except* TypeError as type_errors:
+            assert len(type_errors.exceptions) == 2
+        except* UnexpectedStatus as status_errors:
+            assert len(status_errors.exceptions) == 1
+        except* ValueError as value_errors:
+            assert len(value_errors.exceptions) == 1
+
+
+def test_except_star_valueerror_first():
+    with context_for_test('app_various_errors') as module:
+        app = module.app
+        config = {
+            'output': {'type': 'dict'},
+        }
+
+        try:
+            freeze(app, config)
+        except* TypeError as type_errors:
+            assert len(type_errors.exceptions) == 2
+        except* ValueError as value_errors:
+            # UnexpectedStatus is a ValueError
+            assert len(value_errors.exceptions) == 2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,pyflakes,mypy
+envlist = py36,py37,py38,py39,py310,py311,pyflakes,mypy
 
 [testenv]
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ commands =
     python -m pytest -v
 
 [testenv:pyflakes]
-basepython = python3.10
+basepython = python3.11
 extras =
     dev
 commands =


### PR DESCRIPTION
Also, [Add Python 3.11 to Tox environments](https://github.com/encukou/freezeyt/commit/dec70f52a449f9f19299a18bee53a90ae7febe41)

Fixes: #252

