### PR TITLE
React to the Freezeyt-Action header

### DIFF
--- a/freezeyt/actions.py
+++ b/freezeyt/actions.py
@@ -1,0 +1,54 @@
+from typing import Callable, TYPE_CHECKING
+
+from freezeyt.hooks import TaskInfo
+from freezeyt.util import add_port
+
+ActionFunction = Callable[[TaskInfo], str]
+
+
+def warn(task: TaskInfo) -> str:
+    task._freezer.warnings.append(
+        f"URL {task.get_a_url()},"
+        + f" status code: {task._task.response_status[:3]} was freezed"
+    )
+
+    return 'save'
+
+
+def follow(task: TaskInfo) -> str:
+    location = task._task.response_headers['Location']
+    location = add_port(task._task.get_a_url().join(location))
+
+    target_task = task._freezer.add_task(
+        location,
+        external_ok=True,
+        reason=f'target of redirect from: {task._task.path}',
+    )
+
+    task._task.redirects_to = target_task
+    del task._freezer.inprogress_tasks[task._task.path]
+    task._freezer.redirecting_tasks[task._task.path] = task._task
+
+    return 'follow'
+
+
+def ignore(task: TaskInfo) -> str:
+    return 'ignore'
+
+
+def save(task: TaskInfo) -> str:
+    return 'save'
+
+
+def error(task: TaskInfo) -> str:
+    return 'error'
+
+
+if TYPE_CHECKING:
+    # Check that the default functions have the proper types
+    _: ActionFunction
+    _ = warn
+    _ = follow
+    _ = ignore
+    _ = save
+    _ = error

--- a/freezeyt/freezer.py
+++ b/freezeyt/freezer.py
@@ -17,6 +17,7 @@ from werkzeug.http import parse_options_header
 from werkzeug.urls import URL
 
 import freezeyt
+import freezeyt.actions
 from freezeyt.encoding import encode_wsgi_path, decode_input_path
 from freezeyt.encoding import encode_file_path
 from freezeyt.filesaver import FileSaver
@@ -31,7 +32,7 @@ from freezeyt.compat import StartResponse, WSGIEnvironment, WSGIApplication
 from freezeyt import hooks
 from freezeyt.saver import Saver
 from freezeyt.middleware import Middleware
-from freezeyt.status_handlers import StatusHandler
+from freezeyt.actions import ActionFunction
 from freezeyt.url_finders import UrlFinder
 from freezeyt.extra_files import get_extra_files, get_url_parts_from_directory
 
@@ -193,7 +194,7 @@ class Freezer:
     url_to_path: Union[str, Callable[[str], str]]
 
     url_finders: Dict[str, UrlFinder]
-    status_handlers: Dict[str, StatusHandler]
+    status_handlers: Dict[str, ActionFunction]
 
     def __init__(self, app: WSGIApplication, config: dict):
         self.config = config
@@ -262,7 +263,7 @@ class Freezer:
                 )
 
         self.status_handlers = parse_handlers(
-            _status_handlers, default_module='freezeyt.status_handlers'
+            _status_handlers, default_module='freezeyt.actions'
         )
 
         prefix = config.get('prefix', 'http://localhost:8000/')
@@ -439,7 +440,7 @@ class Freezer:
         elif self.status_handlers.get(status[0] + 'xx'): # handle group statuses from configuration
             status_handler = self.status_handlers.get(status[0] + 'xx')
         elif status.startswith('200'): # default behaviour for status 200
-            status_handler = freezeyt.status_handlers.save
+            status_handler = freezeyt.actions.save
         else:
         # default behaviour for cases which are not handle by conditions above (e.g. groups 1xx, 2xx, ...)
             raise UnexpectedStatus(url, status)

--- a/freezeyt/status_handlers.py
+++ b/freezeyt/status_handlers.py
@@ -3,6 +3,11 @@ import warnings
 from freezeyt.actions import warn, follow, ignore, save, error
 from freezeyt.actions import ActionFunction as StatusHandler
 
+__all__ = [
+    'warn', 'follow', 'ignore', 'save', 'error',
+    'StatusHandler',
+]
+
 warnings.warn(
     'The status_handlers module is deprecated, use freezeyt.actions',
     DeprecationWarning,

--- a/freezeyt/status_handlers.py
+++ b/freezeyt/status_handlers.py
@@ -1,54 +1,9 @@
-from typing import Callable, TYPE_CHECKING
+import warnings
 
-from freezeyt.hooks import TaskInfo
-from freezeyt.util import add_port
+from freezeyt.actions import warn, follow, ignore, save, error
+from freezeyt.actions import ActionFunction as StatusHandler
 
-StatusHandler = Callable[[TaskInfo], str]
-
-
-def warn(task: TaskInfo) -> str:
-    task._freezer.warnings.append(
-        f"URL {task.get_a_url()},"
-        + f" status code: {task._task.response_status[:3]} was freezed"
-    )
-
-    return 'save'
-
-
-def follow(task: TaskInfo) -> str:
-    location = task._task.response_headers['Location']
-    location = add_port(task._task.get_a_url().join(location))
-
-    target_task = task._freezer.add_task(
-        location,
-        external_ok=True,
-        reason=f'target of redirect from: {task._task.path}',
-    )
-
-    task._task.redirects_to = target_task
-    del task._freezer.inprogress_tasks[task._task.path]
-    task._freezer.redirecting_tasks[task._task.path] = task._task
-
-    return 'follow'
-
-
-def ignore(task: TaskInfo) -> str:
-    return 'ignore'
-
-
-def save(task: TaskInfo) -> str:
-    return 'save'
-
-
-def error(task: TaskInfo) -> str:
-    return 'error'
-
-
-if TYPE_CHECKING:
-    # Check that the default functions have the proper types
-    _: StatusHandler
-    _ = warn
-    _ = follow
-    _ = ignore
-    _ = save
-    _ = error
+warnings.warn(
+    'The status_handlers module is deprecated, use freezeyt.actions',
+    DeprecationWarning,
+)

--- a/tests/test_status_handlers.py
+++ b/tests/test_status_handlers.py
@@ -171,3 +171,23 @@ def test_bad_status(status):
 
     with pytest.raises((ValueError, TypeError)):
         freeze(hello_app, config)
+
+
+def test_actions_from_header():
+    app = Flask(__name__)
+    @app.route('/')
+    def index():
+        return '<a href="/ignore_me/">...</a>'
+
+    @app.route('/ignore_me/')
+    def ignored_page():
+        return 'ignored', {'freezeyt-action': 'ignore'}
+
+    config = {
+        'output': {'type': 'dict'},
+    }
+
+    result = freeze(app, config)
+    assert result == {
+        'index.html': b'<a href="/ignore_me/">...</a>',
+    }

--- a/tests/test_status_handlers.py
+++ b/tests/test_status_handlers.py
@@ -103,19 +103,18 @@ def test_default_handlers_error(response_status):
 
     assert e.value.status[:3] == f'{response_status}'
 
+hello_app = Flask(__name__)
+@hello_app.route('/')
+def index():
+    return 'Hello world!'
+
 
 def test_default_behaviour_status_200():
-    app = Flask(__name__)
     config = {
         'output': {'type': 'dict'},
     }
 
-    @app.route('/')
-    def index():
-        return Response(response='Hello world!', status='200')
-
-
-    result = freeze(app, config)
+    result = freeze(hello_app, config)
     assert result == {'index.html': b'Hello world!'}
 
 
@@ -123,29 +122,52 @@ def custom_handler(task):
     return "non_sense"
 
 def test_error_custom_handler():
-    app = Flask(__name__)
     config = {
         'output': {'type': 'dict'},
         'status_handlers': {'200': custom_handler}
     }
 
-    @app.route('/')
-    def index():
-        return 'Hello world!'
-
     with raises_multierror_with_one_exception(UnexpectedStatus):
-        freeze(app, config)
+        freeze(hello_app, config)
+
+
+def old_custom_ignore_handler(task):
+    from freezeyt.status_handlers import ignore
+    return ignore(task)
+
+def test_old_custom_ignore_handler():
+    config = {
+        'output': {'type': 'dict'},
+        'status_handlers': {'200': old_custom_ignore_handler}
+    }
+
+    with pytest.deprecated_call():
+        result = freeze(hello_app, config)
+    assert result == {}
+
+
+def new_custom_ignore_handler(task):
+    from freezeyt.actions import ignore
+    return ignore(task)
+
+def test_new_custom_ignore_handler():
+    config = {
+        'output': {'type': 'dict'},
+        'status_handlers': {'200': new_custom_ignore_handler}
+    }
+
+    result = freeze(hello_app, config)
+    assert result == {}
 
 @pytest.mark.parametrize(
     'status',
     ['ldaskfjhfasdlkdasjh', '', '50x', '50', 50, 'xxx', 'a8xx', '123a'],
 )
 def test_bad_status(status):
-    app = Flask(__name__)
     config = {
         'output': {'type': 'dict'},
         'status_handlers': {status: 'save'}
     }
 
     with pytest.raises((ValueError, TypeError)):
-        freeze(app, config)
+        freeze(hello_app, config)


### PR DESCRIPTION
This allows configuring the action (save, ignore, warn, follow...) from the application itself. Or from custom middleware.

`freezeyt.status_handlers` is renamed to the more general `freezeyt.actions`. Status handlers set the default, used when no `Freezeyt-Action` header is present.