### PR TITLE
Initial static mode for middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,23 @@ if the URL path ends with `/`.
 `url_to_path` cannot be specified in the CLI.
 
 
+### Middleware static mode
+
+When using the `freezeyt` middleware, you can enable *static mode*,
+which simulates behaviour after the app is saved to static pages:
+
+```yaml
+static-mode: true
+```
+
+Currently in static mode, HTTP methods other than GET and HEAD are disallowed.
+
+Other restrictions and features may be added in the future, without regard
+to backwards compatibility.
+The static mode is intended for interactive use -- testing your app without
+having to freeze all of it after each change.
+
+
 ## Examples of CLI usage
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -788,7 +788,7 @@ When using the `freezeyt` middleware, you can enable *static mode*,
 which simulates behaviour after the app is saved to static pages:
 
 ```yaml
-static-mode: true
+static_mode: true
 ```
 
 Currently in static mode, HTTP methods other than GET and HEAD are disallowed.

--- a/freezeyt/middleware.py
+++ b/freezeyt/middleware.py
@@ -114,6 +114,7 @@ class Middleware:
 
         if environ['REQUEST_METHOD'] == 'HEAD':
             # For HEAD, call the app but ignore the response body
+            environ['REQUEST_METHOD'] = 'GET'
             body_iterator = self.app(environ, server_start_response)
             try:
                 close = body_iterator.close

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ dev =
     bottle
     falcon
     freezegun
+    packaging
 blog =
     flask
     markdown-it-py

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -137,6 +137,10 @@ def test_middleware_rejects_wrong_mimetype():
         with pytest.raises(WrongMimetypeError):
             mw_client.get('/image.jpg')
 
+        # Non-GET requests aren't checked
+        mw_client.post('/image.jpg')
+        mw_client.put('/image.jpg')
+
 
 def test_middleware_tricky_extra_files():
     with context_for_test('tricky_extra_files') as module:

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -184,7 +184,7 @@ METHODS = 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'
 @pytest.mark.parametrize('method', METHODS)
 def test_static_mode_disallows_methods(method):
     config = {
-        'static-mode': True,
+        'static_mode': True,
     }
     app = Flask(__name__)
 
@@ -207,7 +207,7 @@ def test_static_mode_disallows_methods(method):
 @pytest.mark.parametrize('path', ('/index.html', '*'))
 def test_static_mode_options(path):
     config = {
-        'static-mode': True,
+        'static_mode': True,
     }
     app = Flask(__name__)
     @app.route('/index.html')

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,7 +1,9 @@
+import werkzeug
 from werkzeug.test import Client
 from werkzeug.datastructures import Headers
 import freezegun
 from flask import Flask
+from packaging.version import Version
 
 import pytest
 
@@ -219,7 +221,13 @@ def test_static_mode_options(path):
     response = mw_client.options(path)
     assert response.status.startswith('200')
     assert response.get_data() == b''
-    assert response.headers == Headers({'Allow': 'GET, HEAD, OPTIONS'})
+
+    # Werkzeug's response headers were fixed in 2.2.0,
+    # see https://github.com/pallets/werkzeug/issues/2450
+    if Version(werkzeug.__version__) >= Version('2.2.0'):
+        assert response.headers == Headers({'Allow': 'GET, HEAD, OPTIONS'})
+    else:
+        assert response.headers['Allow'] == 'GET, HEAD, OPTIONS'
 
 @pytest.mark.parametrize('app_name', APP_NAMES)
 @freezegun.freeze_time()  # freeze time so that Date headers don't change

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -199,3 +199,19 @@ def test_static_mode_disallows_methods(method):
 
     # HTTP status 405: Method Not Allowed
     assert mw_client.open('/index.html', method=method).status.startswith('405')
+
+@pytest.mark.parametrize('path', ('/index.html', '*'))
+def test_static_mode_options(path):
+    config = {
+        'static-mode': True,
+    }
+    app = Flask(__name__)
+    @app.route('/index.html')
+    def index():
+        return 'OK'
+    mw_client = Client(Middleware(app, config))
+
+    response = mw_client.options(path)
+    assert response.status.startswith('200')
+    assert response.get_data() == b''
+    assert response.headers == {'Allow': 'GET, HEAD, OPTIONS'}

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,4 +1,5 @@
 from werkzeug.test import Client
+from werkzeug.datastructures import Headers
 import freezegun
 from flask import Flask
 
@@ -180,15 +181,15 @@ def test_middleware_tricky_extra_files():
         assert not mw_client.get('/static//etc/passwd').status.startswith('200')
 
 
-METHODS = 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'
-@pytest.mark.parametrize('method', METHODS)
+DYNAMIC_METHODS = 'POST', 'PUT', 'PATCH', 'DELETE'
+@pytest.mark.parametrize('method', DYNAMIC_METHODS)
 def test_static_mode_disallows_methods(method):
     config = {
         'static_mode': True,
     }
     app = Flask(__name__)
 
-    @app.route('/index.html', methods=METHODS)
+    @app.route('/index.html', methods=('GET', *DYNAMIC_METHODS))
     def index():
         return 'OK'
 
@@ -218,4 +219,4 @@ def test_static_mode_options(path):
     response = mw_client.options(path)
     assert response.status.startswith('200')
     assert response.get_data() == b''
-    assert response.headers == {'Allow': 'GET, HEAD, OPTIONS'}
+    assert response.headers == Headers({'Allow': 'GET, HEAD, OPTIONS'})


### PR DESCRIPTION
When using the `freezeyt` middleware, you can enable *static mode*,
which simulates behaviour after the app is saved to static pages:

```yaml
static_mode: true
```

Currently in static mode, HTTP methods other than GET and HEAD are disallowed.

Other restrictions and features may be added in the future, without regard
to backwards compatibility.
The static mode is intended for interactive use -- testing your app without
having to freeze all of it after each change.

