### PR TITLE
Use a more realistic CNAME example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ extra_files:
     static:
         copy_from: static/
     # Web host configuration
-    CNAME: https://mysite.example.com/
+    CNAME: mysite.example.com
     ".nojekyll": ''
     googlecc704f0f191eda8f.html:
         copy_from: google-verification.html


### PR DESCRIPTION
On GitHub pages, the CNAME file is supposed to have a domain name in it.

The filename suggests we are talking about domain names, not URLs.

There is another CNAME example later in the README that also has a domain name in it.