### PR TITLE
Add tests for dictsaver & handle edge cases

### DIFF
--- a/freezeyt/dictsaver.py
+++ b/freezeyt/dictsaver.py
@@ -1,6 +1,6 @@
 from io import BytesIO
 from pathlib import PurePosixPath
-from typing import Dict, Union, Iterable
+from typing import Dict, Union, Iterable, Tuple
 
 from .saver import Saver
 
@@ -9,7 +9,7 @@ from .saver import Saver
 DictSaverContents = Dict[
     str,  # filename; maps to either:
     Union[
-        bytes,  # file contents, or
+        bytes,  # file content, or
         'DictSaverContents',  # a subdirectory.
     ]
 ]
@@ -18,51 +18,55 @@ class DictSaver(Saver):
     """Outputs frozen pages into a dict.
     """
     def __init__(self):
-        self.contents: DictSaverContents = {}
+        self.root_dir: DictSaverContents = {}
 
     async def save_to_filename(
         self,
-        filename: PurePosixPath,
+        filepath: PurePosixPath,
         content_iterable: Iterable[bytes],
     ) -> None:
-        path = PurePosixPath(filename)
-        if path.is_absolute():
-            raise ValueError('filename must be relative')
-        parts = path.parts
-        if not parts:
-            raise IsADirectoryError('.')
+        parent_dir, name = get_parent_and_name(self.root_dir, filepath)
 
-        target: DictSaverContents = self.contents
-        for part in parts[:-1]:
-            new_target = target.setdefault(part, {})
-            if not isinstance(new_target, dict):
-                raise NotADirectoryError(PurePosixPath(*parts[:-1]))
-            target = new_target
-        if isinstance(target.get(parts[-1]), dict):
-            raise IsADirectoryError(filename)
-        target[parts[-1]] = b''.join(content_iterable)
+        if isinstance(parent_dir.get(name), dict):
+            raise IsADirectoryError(filepath)
+        parent_dir[name] = b''.join(content_iterable)
 
-    async def open_filename(self, filename: PurePosixPath) -> BytesIO:
-        path = PurePosixPath(filename)
-        if path.is_absolute():
-            raise ValueError('filename must be relative')
-        parts = path.parts
-        if not parts:
-            raise IsADirectoryError('.')
+    async def open_filename(self, filepath: PurePosixPath) -> BytesIO:
+        parent_dir, name = get_parent_and_name(self.root_dir, filepath)
 
-        target: DictSaverContents = self.contents
-        for part in parts[:-1]:
-            new_target = target.setdefault(part, {})
-            if not isinstance(new_target, dict):
-                raise NotADirectoryError(PurePosixPath(*parts[:-1]))
-            target = new_target
         try:
-            contents = target[parts[-1]]
+            file_content = parent_dir[name]
         except KeyError:
-            raise FileNotFoundError(filename)
-        if isinstance(contents, dict):
-            raise IsADirectoryError(filename)
-        return BytesIO(contents)
+            raise FileNotFoundError(filepath)
+        if isinstance(file_content, dict):
+            raise IsADirectoryError(filepath)
+        return BytesIO(file_content)
 
     async def finish(self, success: bool, cleanup: bool) -> DictSaverContents:
-        return self.contents
+        return self.root_dir
+
+def get_parent_and_name(
+    root_dir: DictSaverContents,
+    filepath: PurePosixPath,
+) -> Tuple[DictSaverContents, str]:
+    """Return a dict representing the parent directory of the given file, and
+    the name of the file.
+
+    root_dir: a dict representing the root directory (DictSaver.root_dir)
+    filepath: relative path to the file
+    """
+    path = PurePosixPath(filepath)
+    if path.is_absolute():
+        raise ValueError('filepath must be relative')
+    parts = path.parts
+    if not parts:
+        raise IsADirectoryError('.')
+
+    current_directory: DictSaverContents = root_dir
+    for part in parts[:-1]:
+        new_curdir = current_directory.setdefault(part, {})
+        if not isinstance(new_curdir, dict):
+            raise NotADirectoryError(PurePosixPath(*parts[:-1]))
+        current_directory = new_curdir
+
+    return current_directory, parts[-1]

--- a/freezeyt/dictsaver.py
+++ b/freezeyt/dictsaver.py
@@ -6,12 +6,8 @@ from .saver import Saver
 
 class DictSaver(Saver):
     """Outputs frozen pages into a dict.
-
-    prefix - Base URL to deploy web app in production
-        (eg. url_parse('http://example.com:8000/foo/')
     """
-    def __init__(self, prefix):
-        self.prefix = prefix
+    def __init__(self):
         self.contents = {}
 
     async def save_to_filename(self, filename, content_iterable):

--- a/freezeyt/dictsaver.py
+++ b/freezeyt/dictsaver.py
@@ -1,29 +1,68 @@
 from io import BytesIO
 from pathlib import PurePosixPath
+from typing import Dict, Union, Iterable
 
 from .saver import Saver
 
+
+# Type for holding simulated directory contents.
+DictSaverContents = Dict[
+    str,  # filename; maps to either:
+    Union[
+        bytes,  # file contents, or
+        'DictSaverContents',  # a subdirectory.
+    ]
+]
 
 class DictSaver(Saver):
     """Outputs frozen pages into a dict.
     """
     def __init__(self):
-        self.contents = {}
+        self.contents: DictSaverContents = {}
 
-    async def save_to_filename(self, filename, content_iterable):
-        parts = PurePosixPath(filename).parts
+    async def save_to_filename(
+        self,
+        filename: PurePosixPath,
+        content_iterable: Iterable[bytes],
+    ) -> None:
+        path = PurePosixPath(filename)
+        if path.is_absolute():
+            raise ValueError('filename must be relative')
+        parts = path.parts
+        if not parts:
+            raise IsADirectoryError('.')
 
-        target = self.contents
+        target: DictSaverContents = self.contents
         for part in parts[:-1]:
-            target = target.setdefault(part, {})
+            new_target = target.setdefault(part, {})
+            if not isinstance(new_target, dict):
+                raise NotADirectoryError(PurePosixPath(*parts[:-1]))
+            target = new_target
+        if isinstance(target.get(parts[-1]), dict):
+            raise IsADirectoryError(filename)
         target[parts[-1]] = b''.join(content_iterable)
 
-    async def open_filename(self, filename):
-        parts = PurePosixPath(filename).parts
-        target = self.contents
-        for part in parts[:-1]:
-            target = target.setdefault(part, {})
-        return BytesIO(target[parts[-1]])
+    async def open_filename(self, filename: PurePosixPath) -> BytesIO:
+        path = PurePosixPath(filename)
+        if path.is_absolute():
+            raise ValueError('filename must be relative')
+        parts = path.parts
+        if not parts:
+            raise IsADirectoryError('.')
 
-    async def finish(self, success, cleanup):
+        target: DictSaverContents = self.contents
+        for part in parts[:-1]:
+            new_target = target.setdefault(part, {})
+            if not isinstance(new_target, dict):
+                raise NotADirectoryError(PurePosixPath(*parts[:-1]))
+            target = new_target
+        try:
+            contents = target[parts[-1]]
+        except KeyError:
+            raise FileNotFoundError(filename)
+        if isinstance(contents, dict):
+            raise IsADirectoryError(filename)
+        return BytesIO(contents)
+
+    async def finish(self, success: bool, cleanup: bool) -> DictSaverContents:
         return self.contents

--- a/freezeyt/freezer.py
+++ b/freezeyt/freezer.py
@@ -290,7 +290,7 @@ class Freezer:
             output = {'type': 'dir', 'dir': output}
 
         if output['type'] == 'dict':
-            self.saver = DictSaver(self.prefix)
+            self.saver = DictSaver()
         elif output['type'] == 'dir':
             try:
                 output_dir = output['dir']

--- a/tests/test_dictsaver.py
+++ b/tests/test_dictsaver.py
@@ -23,18 +23,14 @@ def test_save_file(success, cleanup):
     }
 
 
-@pytest.mark.parametrize('cleanup', (True, False))
-@pytest.mark.parametrize('success', (True, False))
-def test_open_root(success, cleanup):
+def test_open_root():
     saver = DictSaver()
 
     with pytest.raises(IsADirectoryError) as err_info:
         asyncio_run(saver.open_filename(PurePosixPath('')))
     assert str(err_info.value) == '.'
 
-@pytest.mark.parametrize('cleanup', (True, False))
-@pytest.mark.parametrize('success', (True, False))
-def test_absolute(success, cleanup):
+def test_absolute():
     saver = DictSaver()
     with pytest.raises(ValueError):
         asyncio_run(saver.open_filename(PurePosixPath('/')))
@@ -46,9 +42,7 @@ def test_absolute(success, cleanup):
         asyncio_run(saver.save_to_filename(PurePosixPath('/a/b/c'), []))
 
 
-@pytest.mark.parametrize('cleanup', (True, False))
-@pytest.mark.parametrize('success', (True, False))
-def test_open_file(success, cleanup):
+def test_open_file():
     saver = DictSaver()
     asyncio_run(saver.save_to_filename(PurePosixPath('test.txt'), [b'text']))
 
@@ -56,9 +50,7 @@ def test_open_file(success, cleanup):
     assert file.read() == b'text'
 
 
-@pytest.mark.parametrize('cleanup', (True, False))
-@pytest.mark.parametrize('success', (True, False))
-def test_open_dir(success, cleanup):
+def test_open_dir():
     saver = DictSaver()
     asyncio_run(saver.save_to_filename(PurePosixPath('d/test.txt'), [b'text']))
 
@@ -72,9 +64,7 @@ def test_open_dir(success, cleanup):
 
 
 
-@pytest.mark.parametrize('cleanup', (True, False))
-@pytest.mark.parametrize('success', (True, False))
-def test_open_file_in_file(success, cleanup):
+def test_open_file_in_file():
     saver = DictSaver()
     asyncio_run(saver.save_to_filename(PurePosixPath('d/test.txt'), [b'text']))
 
@@ -84,9 +74,7 @@ def test_open_file_in_file(success, cleanup):
 
 
 
-@pytest.mark.parametrize('cleanup', (True, False))
-@pytest.mark.parametrize('success', (True, False))
-def test_open_missing_file(success, cleanup):
+def test_open_missing_file():
     saver = DictSaver()
     asyncio_run(saver.save_to_filename(PurePosixPath('d/test.txt'), [b'text']))
 
@@ -164,9 +152,7 @@ def test_overwrite(success, cleanup):
     }
 
 
-@pytest.mark.parametrize('cleanup', (True, False))
-@pytest.mark.parametrize('success', (True, False))
-def test_save_dir_to_file(success, cleanup):
+def test_save_dir_to_file():
     saver = DictSaver()
     asyncio_run(saver.save_to_filename(PurePosixPath('t'), [b't']))
     with pytest.raises(NotADirectoryError) as err_info:
@@ -174,9 +160,7 @@ def test_save_dir_to_file(success, cleanup):
     assert str(err_info.value) == 't/x'
 
 
-@pytest.mark.parametrize('cleanup', (True, False))
-@pytest.mark.parametrize('success', (True, False))
-def test_save_file_to_dir(success, cleanup):
+def test_save_file_to_dir():
     saver = DictSaver()
     asyncio_run(saver.save_to_filename(PurePosixPath('t/f'), [b'f']))
     with pytest.raises(IsADirectoryError):

--- a/tests/test_dictsaver.py
+++ b/tests/test_dictsaver.py
@@ -1,0 +1,183 @@
+from pathlib import PurePosixPath
+
+from freezeyt.compat import asyncio_run
+from freezeyt.dictsaver import DictSaver
+
+import pytest
+
+
+@pytest.mark.parametrize('cleanup', (True, False))
+@pytest.mark.parametrize('success', (True, False))
+def test_empty(success, cleanup):
+    saver = DictSaver()
+    assert asyncio_run(saver.finish(success, cleanup)) == {}
+
+
+@pytest.mark.parametrize('cleanup', (True, False))
+@pytest.mark.parametrize('success', (True, False))
+def test_save_file(success, cleanup):
+    saver = DictSaver()
+    asyncio_run(saver.save_to_filename(PurePosixPath('test.txt'), [b'text']))
+    assert asyncio_run(saver.finish(success, cleanup)) == {
+        'test.txt': b'text',
+    }
+
+
+@pytest.mark.parametrize('cleanup', (True, False))
+@pytest.mark.parametrize('success', (True, False))
+def test_open_root(success, cleanup):
+    saver = DictSaver()
+
+    with pytest.raises(IsADirectoryError) as err_info:
+        asyncio_run(saver.open_filename(PurePosixPath('')))
+    assert str(err_info.value) == '.'
+
+@pytest.mark.parametrize('cleanup', (True, False))
+@pytest.mark.parametrize('success', (True, False))
+def test_absolute(success, cleanup):
+    saver = DictSaver()
+    with pytest.raises(ValueError):
+        asyncio_run(saver.open_filename(PurePosixPath('/')))
+    with pytest.raises(ValueError):
+        asyncio_run(saver.open_filename(PurePosixPath('/a/b/c')))
+    with pytest.raises(ValueError):
+        asyncio_run(saver.save_to_filename(PurePosixPath('/'), []))
+    with pytest.raises(ValueError):
+        asyncio_run(saver.save_to_filename(PurePosixPath('/a/b/c'), []))
+
+
+@pytest.mark.parametrize('cleanup', (True, False))
+@pytest.mark.parametrize('success', (True, False))
+def test_open_file(success, cleanup):
+    saver = DictSaver()
+    asyncio_run(saver.save_to_filename(PurePosixPath('test.txt'), [b'text']))
+
+    file = asyncio_run(saver.open_filename(PurePosixPath('test.txt')))
+    assert file.read() == b'text'
+
+
+@pytest.mark.parametrize('cleanup', (True, False))
+@pytest.mark.parametrize('success', (True, False))
+def test_open_dir(success, cleanup):
+    saver = DictSaver()
+    asyncio_run(saver.save_to_filename(PurePosixPath('d/test.txt'), [b'text']))
+
+    with pytest.raises(IsADirectoryError) as err_info:
+        asyncio_run(saver.open_filename(PurePosixPath('d')))
+    assert str(err_info.value) == 'd'
+
+    with pytest.raises(IsADirectoryError) as err_info:
+        asyncio_run(saver.open_filename(PurePosixPath('')))
+    assert str(err_info.value) == '.'
+
+
+
+@pytest.mark.parametrize('cleanup', (True, False))
+@pytest.mark.parametrize('success', (True, False))
+def test_open_file_in_file(success, cleanup):
+    saver = DictSaver()
+    asyncio_run(saver.save_to_filename(PurePosixPath('d/test.txt'), [b'text']))
+
+    with pytest.raises(NotADirectoryError) as err_info:
+        asyncio_run(saver.open_filename(PurePosixPath('d/test.txt/file')))
+    assert str(err_info.value) == 'd/test.txt'
+
+
+
+@pytest.mark.parametrize('cleanup', (True, False))
+@pytest.mark.parametrize('success', (True, False))
+def test_open_missing_file(success, cleanup):
+    saver = DictSaver()
+    asyncio_run(saver.save_to_filename(PurePosixPath('d/test.txt'), [b'text']))
+
+    with pytest.raises(FileNotFoundError) as err_info:
+        asyncio_run(saver.open_filename(PurePosixPath('d/bad_file')))
+    assert str(err_info.value) == 'd/bad_file'
+
+
+@pytest.mark.parametrize('cleanup', (True, False))
+@pytest.mark.parametrize('success', (True, False))
+def test_save_iter(success, cleanup):
+    saver = DictSaver()
+    asyncio_run(saver.save_to_filename(PurePosixPath('test.txt'), [
+        b'text1', b'text2',
+    ]))
+    asyncio_run(saver.save_to_filename(PurePosixPath('empty.txt'), []))
+    assert asyncio_run(saver.finish(success, cleanup)) == {
+        'test.txt': b'text1text2',
+        'empty.txt': b'',
+    }
+
+
+@pytest.mark.parametrize('cleanup', (True, False))
+@pytest.mark.parametrize('success', (True, False))
+def test_save_subdir(success, cleanup):
+    saver = DictSaver()
+    asyncio_run(saver.save_to_filename(PurePosixPath('a/b/t'), [b'text']))
+    assert asyncio_run(saver.finish(success, cleanup)) == {
+        'a': {
+            'b': {
+                't': b'text',
+            }
+        }
+    }
+
+
+@pytest.mark.parametrize('cleanup', (True, False))
+@pytest.mark.parametrize('success', (True, False))
+def test_save_many(success, cleanup):
+    saver = DictSaver()
+    asyncio_run(saver.save_to_filename(PurePosixPath('a/b/t'), [b'a/b/t']))
+    asyncio_run(saver.save_to_filename(PurePosixPath('a/c/t'), [b'a/c/t']))
+    asyncio_run(saver.save_to_filename(PurePosixPath('a/t'), [b'a/t']))
+    asyncio_run(saver.save_to_filename(PurePosixPath('a/b/c/t'), [b'a/b/c/t']))
+    asyncio_run(saver.save_to_filename(PurePosixPath('d/t'), [b'd/t']))
+    asyncio_run(saver.save_to_filename(PurePosixPath('t'), [b't']))
+    assert asyncio_run(saver.finish(success, cleanup)) == {
+        't': b't',
+        'a': {
+            't': b'a/t',
+            'b': {
+                't': b'a/b/t',
+                'c': {
+                    't': b'a/b/c/t',
+                },
+            },
+            'c': {
+                't': b'a/c/t',
+            },
+        },
+        'd': {
+            't': b'd/t',
+        },
+    }
+
+
+@pytest.mark.parametrize('cleanup', (True, False))
+@pytest.mark.parametrize('success', (True, False))
+def test_overwrite(success, cleanup):
+    saver = DictSaver()
+    asyncio_run(saver.save_to_filename(PurePosixPath('test.txt'), [b'orig']))
+    asyncio_run(saver.save_to_filename(PurePosixPath('test.txt'), [b'new']))
+    assert asyncio_run(saver.finish(success, cleanup)) == {
+        'test.txt': b'new',
+    }
+
+
+@pytest.mark.parametrize('cleanup', (True, False))
+@pytest.mark.parametrize('success', (True, False))
+def test_save_dir_to_file(success, cleanup):
+    saver = DictSaver()
+    asyncio_run(saver.save_to_filename(PurePosixPath('t'), [b't']))
+    with pytest.raises(NotADirectoryError) as err_info:
+        asyncio_run(saver.save_to_filename(PurePosixPath('t/x/f'), [b'f']))
+    assert str(err_info.value) == 't/x'
+
+
+@pytest.mark.parametrize('cleanup', (True, False))
+@pytest.mark.parametrize('success', (True, False))
+def test_save_file_to_dir(success, cleanup):
+    saver = DictSaver()
+    asyncio_run(saver.save_to_filename(PurePosixPath('t/f'), [b'f']))
+    with pytest.raises(IsADirectoryError):
+        asyncio_run(saver.save_to_filename(PurePosixPath('t'), [b't']))


### PR DESCRIPTION
Raise proper errors on operations that wouldn't be valid on a regular filesystem, like replacing a directory with a regular file or creating a sub-directory of a regular file.

Also, add typing to DictSaver.