### PR TITLE
Pin to older version of types-html5lib

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,9 @@ typecheck =
     mypy
     types-click
     types-PyYAML
-    types-html5lib
+
+    # Pin old version for: https://github.com/python/typeshed/issues/11478
+    types-html5lib < 1.1.11.20240221
 
 
 [options.entry_points]


### PR DESCRIPTION
This avoids a typing issue reported here:
https://github.com/python/typeshed/issues/11478