### PR TITLE
Extend install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ of virtual environment.
 [`venv`]: https://docs.python.org/3/library/venv.html?highlight=venv#module-venv
 
 The most recent release can be installed using:
-```commandline
+```
 $ python -m pip install freezeyt
 ```
 
 The tool can also be installed from source using:
-```commandline
+```
 $ python -m pip install .
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,12 +30,16 @@ of virtual environment.
 
 [`venv`]: https://docs.python.org/3/library/venv.html?highlight=venv#module-venv
 
-The tool can be installed using:
+The most recent release can be installed using:
 
+```commandline
+$ python -m pip install freezeyt
 ```
+
+The tool can also be installed from source using:
+```commandline
 $ python -m pip install .
 ```
-
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ of virtual environment.
 [`venv`]: https://docs.python.org/3/library/venv.html?highlight=venv#module-venv
 
 The most recent release can be installed using:
-
 ```commandline
 $ python -m pip install freezeyt
 ```
@@ -40,6 +39,7 @@ The tool can also be installed from source using:
 ```commandline
 $ python -m pip install .
 ```
+
 
 ## Usage
 


### PR DESCRIPTION
I wanted to test it out and I had to go to PyPI to see if it was published there or if I had to install from source. This is just a small extension to the Installation section that clarifies this, especially since most people install from PyPI due to the convenience.