### PR TITLE
Really fail fast

### DIFF
--- a/freezeyt/compat.py
+++ b/freezeyt/compat.py
@@ -111,9 +111,11 @@ else:
         """
         def __init__(self, n):
             self.remaining = n
-            self.event = asyncio.Event()
+            self.event = None
 
         async def wait(self):
+            if self.event is None:
+                self.event = asyncio.Event()
             self.remaining -= 1
             if self.remaining <= 0:
                 self.event.set()

--- a/freezeyt/compat.py
+++ b/freezeyt/compat.py
@@ -100,3 +100,22 @@ else:
     # Ignore it on earlier versions.
     def warnings_warn(*args, skip_file_prefixes=None, **kwargs):
         return warnings.warn(*args, **kwargs)
+
+if sys.version_info >= (3, 11):
+    asyncio_Barrier = asyncio.Barrier
+else:
+    class asyncio_Barrier:
+        """Simple version of Barrier.
+
+        Only handles one batch of parties.
+        """
+        def __init__(self, n):
+            self.remaining = n
+            self.event = asyncio.Event()
+
+        async def wait(self):
+            self.remaining -= 1
+            if self.remaining <= 0:
+                self.event.set()
+            else:
+                await self.event.wait()

--- a/tests/test_cancel_tasks.py
+++ b/tests/test_cancel_tasks.py
@@ -43,7 +43,6 @@ def test_fail_fast_cancels_tasks(monkeypatch, tmp_path):
 
     num_cancelled_errors = 0
 
-    event = asyncio.Event()  # this event will never be set
     barrier = asyncio_Barrier(N_PAGES)
 
     async def fake_save_to_filename(self, filename, content_iterable):
@@ -55,7 +54,7 @@ def test_fail_fast_cancels_tasks(monkeypatch, tmp_path):
         else:
             try:
                 await barrier.wait() # wait for all tasks to reach this barrier
-                await event.wait()   # wait for cancellation
+                await asyncio.Event().wait()   # wait for cancellation
             except asyncio.CancelledError:
                 num_cancelled_errors += 1
                 raise

--- a/tests/test_cancel_tasks.py
+++ b/tests/test_cancel_tasks.py
@@ -1,8 +1,12 @@
+import asyncio
+import sys
+
+import pytest
+
 from freezeyt import freeze, UnexpectedStatus
-from freezeyt.freezer import Freezer
+from freezeyt.freezer import Freezer, FileSaver
 from fixtures.app_cleanup_config.app import app
 from testutil import raises_multierror_with_one_exception
-import sys
 
 
 def test_cancel_tasks_was_called(monkeypatch):
@@ -24,3 +28,55 @@ if sys.version_info >= (3, 8):
                 freeze(app, {'output': {'type': 'dict'}})
 
         assert mock_method.called
+
+def test_fail_fast_cancels_tasks(monkeypatch, tmp_path):
+    """Test that with fail_fast, tasks are cancelled after an error.
+
+    This works by trying to save a lot of pages, one of which raises an error
+    and the other ones take forever to complete.
+    """
+    NUM = 20
+    N_CANCELLED_PAGES = NUM * 2 + 1  # includes index.html
+    N_PAGES = N_CANCELLED_PAGES + 1  # includes index.html & error.html
+    # (N_PAGES must be lower than freezer.MAX_RUNNING_TASKS)
+
+    num_cancelled_errors = 0
+
+    barrier = asyncio.Barrier(N_PAGES)
+    event = asyncio.Event()  # this event will never be set
+
+    async def fake_save_to_filename(self, filename, content_iterable):
+        """Fake func for replace the save_to_filename method from FileSaver"""
+        nonlocal num_cancelled_errors
+        if filename.name == 'error.html':
+            await barrier.wait() # wait for all tasks to reach this barrier
+            raise ValueError()
+        else:
+            try:
+                await barrier.wait() # wait for all tasks to reach this barrier
+                await event.wait()   # wait for cancellation
+            except asyncio.CancelledError:
+                num_cancelled_errors += 1
+                raise
+
+    monkeypatch.setattr(FileSaver, 'save_to_filename',
+                        fake_save_to_filename, raising=True)
+
+    def app(environ, start_response):
+        start_response('200 OK', [('Content-type', 'text/html')])
+        return []
+
+    config = {
+        'output': str(tmp_path),
+        'extra_pages': [
+            # 'index.html' is frozen automatically
+            *(f'before-{n}.html' for n in range(NUM)),  # N extra pages
+            'error.html',  # this raises an error
+            *(f'after-{n}.html' for n in range(NUM)),  # N extra pages
+        ],
+        'fail_fast': True}
+
+    with pytest.raises(ValueError):
+        freeze(app, config)
+
+    assert num_cancelled_errors == N_CANCELLED_PAGES

--- a/tests/test_cancel_tasks.py
+++ b/tests/test_cancel_tasks.py
@@ -4,6 +4,7 @@ import sys
 import pytest
 
 from freezeyt import freeze, UnexpectedStatus
+from freezeyt.compat import asyncio_Barrier
 from freezeyt.freezer import Freezer, FileSaver
 from fixtures.app_cleanup_config.app import app
 from testutil import raises_multierror_with_one_exception
@@ -42,8 +43,8 @@ def test_fail_fast_cancels_tasks(monkeypatch, tmp_path):
 
     num_cancelled_errors = 0
 
-    barrier = asyncio.Barrier(N_PAGES)
     event = asyncio.Event()  # this event will never be set
+    barrier = asyncio_Barrier(N_PAGES)
 
     async def fake_save_to_filename(self, filename, content_iterable):
         """Fake func for replace the save_to_filename method from FileSaver"""

--- a/tests/test_cancel_tasks.py
+++ b/tests/test_cancel_tasks.py
@@ -48,12 +48,11 @@ def test_fail_fast_cancels_tasks(monkeypatch, tmp_path):
     async def fake_save_to_filename(self, filename, content_iterable):
         """Fake func for replace the save_to_filename method from FileSaver"""
         nonlocal num_cancelled_errors
+        await barrier.wait() # wait for all tasks to reach this barrier
         if filename.name == 'error.html':
-            await barrier.wait() # wait for all tasks to reach this barrier
             raise ValueError()
         else:
             try:
-                await barrier.wait() # wait for all tasks to reach this barrier
                 await asyncio.Event().wait()   # wait for cancellation
             except asyncio.CancelledError:
                 num_cancelled_errors += 1

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -375,9 +375,9 @@ def test_page_failed_hook():
 
     def record_frozen(task_info):
         check_task_counts(task_info.freeze_info, expected_total)
+        assert task_info.path == 'index.html'
         records.append((
             'frozen',
-            task_info.path,
             task_info.freeze_info.total_task_count,
             task_info.freeze_info.done_task_count,
             task_info.freeze_info.failed_task_count,
@@ -386,9 +386,9 @@ def test_page_failed_hook():
 
     def record_fail(task_info):
         check_task_counts(task_info.freeze_info, expected_total)
+        assert task_info.path in {'nowhere', 'also_nowhere'}
         records.append((
             'failed',
-            task_info.path,
             task_info.freeze_info.total_task_count,
             task_info.freeze_info.done_task_count,
             task_info.freeze_info.failed_task_count,
@@ -409,7 +409,7 @@ def test_page_failed_hook():
             freeze(module.app, config)
 
     assert records == [
-        ('frozen', 'index.html', 3, 1, 0),
-        ('failed', 'nowhere', 3, 2, 1),
-        ('failed', 'also_nowhere', 3, 3, 2),
+        ('frozen', 3, 1, 0),
+        ('failed', 3, 2, 1),
+        ('failed', 3, 3, 2),
     ]


### PR DESCRIPTION
fixes: https://github.com/encukou/freezeyt/issues/341

Use `asyncio.wait` to process done tasks first.
Add a test to ensure that in fail-fast mode, a failed task cancels all others.

Adjust `test_page_failed_hook` to allow for different order of tasks. (`asyncio.wait` internally uses a set.)
