### PR TITLE
test_logging: Fix compatibility with Click 8.2

### DIFF
--- a/tests/test_click_cli.py
+++ b/tests/test_click_cli.py
@@ -351,12 +351,11 @@ def test_cli_fail_fast_option_priority_enable(tmp_path):
 
 def test_help():
     """Test that -h does the same as --help: show the help."""
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     result_help = runner.invoke(main, ['--help'])
     result_h = runner.invoke(main, ['-h'])
 
-    assert result_help.stdout == result_h.stdout
-    assert result_help.stderr == result_h.stderr == ''
+    assert result_help.output == result_h.output
     assert result_help.exit_code == result_h.exit_code == 0
 
     assert 'Usage:' in result_help.stdout


### PR DESCRIPTION
The `mix_stderr` parameter was removed; but `output` is always available and is a mix of stdout and stderr.