### PR TITLE
Display URL query in 'file requested from multiple URLs' warning messages

### DIFF
--- a/freezeyt/freezer.py
+++ b/freezeyt/freezer.py
@@ -413,15 +413,29 @@ class Freezer:
 
             for task in self.done_tasks.values():
                 if len(task.urls) > 1:
+                    display_urls = sorted(
+                        [self.get_short_url(url) for url in task.urls]
+                    )
+
                     self.warnings.append(
                         f"Static file '{task.path}' is requested from"
-                        f" different URLs {sorted([url.path for url in task.urls])}"
+                        f" different URLs {display_urls}"
                     )
 
             for warning in self.warnings:
                 print(f"[WARNING] {warning}")
             return result
         raise MultiError(self.failed_tasks.values())
+
+    def get_short_url(self, url):
+        """Return short version of an URL for a warning/error message"""
+        # Remove self.prefix if the URL starts with it.
+        # If it doesn't for any reason, it's OK to leave it in.
+        prefix_str = str(self.prefix)[:-1]
+        url_str = str(url)
+        if url_str.startswith(prefix_str):
+            return url_str[len(prefix_str):]
+        return url_str
 
     def add_task(
         self,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -38,13 +38,14 @@ def test_warn_same_frozen_file_from_different_URLs(capsys):
 
     app = Flask(__name__)
 
-    index_routes = ['/', '/index.html']
+    index_routes = ['/', '/index.html', '/index.html?a=b']
     second_page_routes = ['/second_page/', '/second_page/index.html']
 
     @app.route(index_routes[0])
     def index():
         return """
     <a href='/index.html'>INDEX FILE</a>
+    <a href='/index.html?a=b'>INDEX FILE</a>
     <a href='/second_page/index.html'>SECOND PAGE FILE</a>
 """
 


### PR DESCRIPTION
Without it, we could get duplicate entries in the message.

This should help with #414, if not fix it.